### PR TITLE
[r-rig] Do not set `PKG_SYSREQS="true"` in the Rprofile

### DIFF
--- a/src/r-rig/devcontainer-feature.json
+++ b/src/r-rig/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
 	"name": "R (via rig)",
 	"id": "r-rig",
-	"version": "0.3.0",
+	"version": "0.3.1",
 	"description": "Installs R, rig, some R packages, and needed dependencies. Note: May require source code compilation for R packages.",
 	"options": {
 		"version": {

--- a/src/r-rig/install.sh
+++ b/src/r-rig/install.sh
@@ -212,7 +212,7 @@ if [ "${R_VERSION}" = "none" ]; then
 fi
 
 echo "Downloading R ${R_VERSION}..."
-rig add "${R_VERSION}" --without-pak
+rig add "${R_VERSION}" --without-pak --without-sysreqs
 
 echo "Install R packages..."
 su ${USERNAME} -c "rig system add-pak"

--- a/src/r-rig/install.sh
+++ b/src/r-rig/install.sh
@@ -27,7 +27,7 @@ if [ "${USERNAME}" = "auto" ] || [ "${USERNAME}" = "automatic" ]; then
     USERNAME=""
     POSSIBLE_USERS=("vscode" "node" "codespace" "$(awk -v val=1000 -F ":" '$3==val{print $1}' /etc/passwd)")
     for CURRENT_USER in "${POSSIBLE_USERS[@]}"; do
-        if id -u "${CURRENT_USER}" > /dev/null 2>&1; then
+        if id -u "${CURRENT_USER}" >/dev/null 2>&1; then
             USERNAME=${CURRENT_USER}
             break
         fi
@@ -35,7 +35,7 @@ if [ "${USERNAME}" = "auto" ] || [ "${USERNAME}" = "automatic" ]; then
     if [ "${USERNAME}" = "" ]; then
         USERNAME=root
     fi
-elif [ "${USERNAME}" = "none" ] || ! id -u ${USERNAME} > /dev/null 2>&1; then
+elif [ "${USERNAME}" = "none" ] || ! id -u ${USERNAME} >/dev/null 2>&1; then
     USERNAME=root
 fi
 
@@ -167,7 +167,7 @@ install_pandoc() {
 install_r_packages() {
     packages="$*"
     if [ -n "${packages}" ]; then
-        su ${USERNAME} -c "R -q -e \"pak::pak(unlist(strsplit('${packages}',' ')))\""
+        su ${USERNAME} -c "R -q -e \"pak::pak(unlist(strsplit('${packages}', ' ')))\""
     fi
 }
 

--- a/src/r-rig/install.sh
+++ b/src/r-rig/install.sh
@@ -215,7 +215,9 @@ echo "Downloading R ${R_VERSION}..."
 rig add "${R_VERSION}" --without-pak --without-sysreqs
 
 echo "Install R packages..."
-su ${USERNAME} -c "rig system add-pak"
+# Install the pak package
+# shellcheck disable=SC2016
+su ${USERNAME} -c 'R -q -e "install.packages(\"pak\", repos = sprintf(\"https://r-lib.github.io/p/pak/stable/%s/%s/%s\", .Platform\$pkgType, R.Version()\$os, R.Version()\$arch))"'
 # shellcheck disable=SC2048 disable=SC2086
 install_r_packages ${R_PACKAGES[*]}
 


### PR DESCRIPTION
R installed with rig has `PKG_SYSREQS="true"` set in `/opt/R/*/lib/R/library/base/R/Rprofile` by default.
This is often useful as it means that system libraries are installed automatically when possible by `pak::pak`, but the user must edit the Rprofile to turn this off.
I found that this setting installing older versions of pandoc on Ubuntu, so I will change this.

This PR also includes other minor refactoring.