### PR TITLE
[r-lig] Allow `latest` for version of R

### DIFF
--- a/src/r-rig/install.sh
+++ b/src/r-rig/install.sh
@@ -39,6 +39,11 @@ elif [ "${USERNAME}" = "none" ] || ! id -u ${USERNAME} >/dev/null 2>&1; then
     USERNAME=root
 fi
 
+# Allow latest as an alias of release for compatibility
+if [ "${R_VERSION}" = "latest" ]; then
+    R_VERSION="release"
+fi
+
 # Check options for installing packages
 if [ "${INSTALL_RMARKDOWN}" = "true" ]; then
     APT_PACKAGES+=(make libicu-dev)

--- a/test/r-rig/scenarios.json
+++ b/test/r-rig/scenarios.json
@@ -24,5 +24,13 @@
 				"pandocVersion": "os-provided"
 			}
 		}
+	},
+	"version-latest": {
+		"image": "debian:stable-slim",
+		"features": {
+			"r-rig": {
+				"version": "latest"
+			}
+		}
 	}
 }

--- a/test/r-rig/version-latest.sh
+++ b/test/r-rig/version-latest.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Optional: Import test library bundled with the devcontainer CLI
+source dev-container-features-test-lib
+
+# Feature-specific tests
+check "version" R -q -e "sessionInfo()"
+
+# Report result
+reportResults


### PR DESCRIPTION
In r-rig, version is passed directly to rig as an argument and `latest` is not a valid value, but it is common for other devcontainer features to allow the version to be specified as `latest`.
Therefore, allow `latest` version for compatibility.