### PR TITLE
[r-lig] Skip install rig but install R packages, when R is already installed

### DIFF
--- a/src/r-rig/NOTES.md
+++ b/src/r-rig/NOTES.md
@@ -8,7 +8,8 @@
 
 This feature uses [rig](https://github.com/r-lib/rig) to install [R](https://www.r-project.org/).
 
-**Do not install this feature on R-installed images**, as rig does not manage R installed outside of rig.
+Note that rig does not manage R installed outside of rig.
+If R is already installed and `"version": "none"` is set, rig will not be installed.
 
 ## R package installation
 

--- a/src/r-rig/devcontainer-feature.json
+++ b/src/r-rig/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
 	"name": "R (via rig)",
 	"id": "r-rig",
-	"version": "0.4.0",
+	"version": "0.5.0",
 	"description": "Installs R, rig, some R packages, and needed dependencies. Note: May require source code compilation for R packages.",
 	"documentationURL": "https://github.com/rocker-org/devcontainer-features/tree/main/src/r-rig",
 	"options": {

--- a/src/r-rig/devcontainer-feature.json
+++ b/src/r-rig/devcontainer-feature.json
@@ -2,7 +2,7 @@
 	"name": "R (via rig)",
 	"id": "r-rig",
 	"version": "0.5.0",
-	"description": "Installs R, rig, some R packages, and needed dependencies. Note: May require source code compilation for R packages.",
+	"description": "Installs R, some R packages, and needed dependencies. Note: May require source code compilation for R packages.",
 	"documentationURL": "https://github.com/rocker-org/devcontainer-features/tree/main/src/r-rig",
 	"options": {
 		"version": {

--- a/src/r-rig/devcontainer-feature.json
+++ b/src/r-rig/devcontainer-feature.json
@@ -28,7 +28,7 @@
 		"installRMarkdown": {
 			"type": "boolean",
 			"default": false,
-			"description": "Install the rmarkdown R package."
+			"description": "Install the `rmarkdown` R package."
 		},
 		"pandocVersion": {
 			"type": "string",

--- a/src/r-rig/install.sh
+++ b/src/r-rig/install.sh
@@ -219,16 +219,24 @@ if [ "${R_VERSION}" != "release" ] && [ "${R_VERSION}" != "devel" ] && [ "${R_VE
 fi
 
 # Install rig
-echo "Downloading rig..."
-install_rig
+if [ "${R_VERSION}" = "none" ] && [ -x "$(command -v R)" ]; then
+    echo "R is already installed. Skipping rig installation"
+else
+    echo "Downloading rig..."
+    install_rig
+fi
 
-if [ "${R_VERSION}" = "none" ]; then
+if [ "${R_VERSION}" = "none" ] && [ ! -x "$(command -v R)" ]; then
     echo "Skipping R and R packages installation"
     exit 0
 fi
 
-echo "Downloading R ${R_VERSION}..."
-rig add "${R_VERSION}" --without-pak --without-sysreqs
+if [ "${R_VERSION}" = "none" ]; then
+    echo "Skipping R installation"
+else
+    echo "Downloading R ${R_VERSION}..."
+    rig add "${R_VERSION}" --without-pak --without-sysreqs
+fi
 
 echo "Install R packages..."
 # Install the pak package

--- a/test/r-rig/install-on-rocker-r-ver.sh
+++ b/test/r-rig/install-on-rocker-r-ver.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Optional: Import test library bundled with the devcontainer CLI
+source dev-container-features-test-lib
+
+# Feature-specific tests
+check "R" R -q -e "sessionInfo()"
+check "pandoc" R -q -e 'rmarkdown::pandoc_version()'
+
+# Report result
+reportResults

--- a/test/r-rig/install-on-rocker-r-ver.sh
+++ b/test/r-rig/install-on-rocker-r-ver.sh
@@ -6,7 +6,7 @@ set -e
 source dev-container-features-test-lib
 
 # Feature-specific tests
-check "R" R -q -e "sessionInfo()"
+check "R" R --version | grep 4.0.5
 check "pandoc" R -q -e 'rmarkdown::pandoc_version()'
 
 # Report result

--- a/test/r-rig/rpackages-source-install.sh
+++ b/test/r-rig/rpackages-source-install.sh
@@ -7,7 +7,9 @@ source dev-container-features-test-lib
 
 # Feature-specific tests
 check "R" R -q -e "sessionInfo()"
-check "pandoc" R -q -e 'rmarkdown::pandoc_version()'
+check "rmarkdown" R -q -e 'rmarkdown::pandoc_version()'
+check "languageserver" R -q -e 'names(installed.packages()[, 3])' | grep languageserver
+check "httpgd" R -q -e 'names(installed.packages()[, 3])' | grep httpgd
 
 # Report result
 reportResults

--- a/test/r-rig/scenarios.json
+++ b/test/r-rig/scenarios.json
@@ -35,7 +35,7 @@
 		}
 	},
 	"install-on-rocker-r-ver": {
-		"image": "rocker/r-ver:4.0",
+		"image": "rocker/r-ver:4.0.5",
 		"features": {
 			"r-rig": {
 				"version": "none",

--- a/test/r-rig/scenarios.json
+++ b/test/r-rig/scenarios.json
@@ -33,5 +33,14 @@
 				"version": "latest"
 			}
 		}
+	},
+	"install-on-rocker-r-ver": {
+		"image": "rocker/r-ver:4.0",
+		"features": {
+			"r-rig": {
+				"version": "none",
+				"installRMarkdown": true
+			}
+		}
 	}
 }


### PR DESCRIPTION
Allows this feature to be used to install R packages on R installed images.

ToDo

- [x] more tests