### PR TITLE
[r-rig] Options to install devtools, jupyterlab, radian

### DIFF
--- a/src/r-rig/NOTES.md
+++ b/src/r-rig/NOTES.md
@@ -57,3 +57,8 @@ $ R -q -e 'pak::pak("curl")'
 ℹ Executing `sudo sh -c apt-get install -y libssl-dev`
 ✔ 1 pkg: kept 1 [11.8s]
 ```
+
+## Python package installation
+
+This feature has some options to install Python packages such as `jupyterlab`.
+When installing Python packages, if `python3 -m pip` is not available, it will install `python3-pip` via apt.

--- a/src/r-rig/devcontainer-feature.json
+++ b/src/r-rig/devcontainer-feature.json
@@ -25,6 +25,11 @@
 			"default": "minimal",
 			"description": "Install R packages to make vscode-R work. lsp means the `languageserver` package, full means lsp plus the `httpgd` package."
 		},
+		"installDevTools": {
+			"type": "boolean",
+			"default": false,
+			"description": "Install the `devtools` R package."
+		},
 		"installRMarkdown": {
 			"type": "boolean",
 			"default": false,

--- a/src/r-rig/devcontainer-feature.json
+++ b/src/r-rig/devcontainer-feature.json
@@ -38,12 +38,12 @@
 		"installJupyterlab": {
 			"type": "boolean",
 			"default": false,
-			"description": "Install and setup JupyterLab, a web-based interactive development environment for notebooks."
+			"description": "Install and setup JupyterLab (via `python3 -m pip`). JupyterLab is a web-based interactive development environment for notebooks."
 		},
 		"installRadian": {
 			"type": "boolean",
 			"default": false,
-			"description": "Install radian, an R console with multiline editing and rich syntax highlight."
+			"description": "Install radian (via `python3 -m pip`). radian is an R console with multiline editing and rich syntax highlight."
 		},
 		"pandocVersion": {
 			"type": "string",

--- a/src/r-rig/devcontainer-feature.json
+++ b/src/r-rig/devcontainer-feature.json
@@ -28,7 +28,7 @@
 		"installRMarkdown": {
 			"type": "boolean",
 			"default": false,
-			"description": "Install the `rmarkdown` R package."
+			"description": "Install the `rmarkdown` R package. It is required for R Markdown or Quarto documentation."
 		},
 		"pandocVersion": {
 			"type": "string",

--- a/src/r-rig/devcontainer-feature.json
+++ b/src/r-rig/devcontainer-feature.json
@@ -30,6 +30,11 @@
 			"default": false,
 			"description": "Install the `rmarkdown` R package. It is required for R Markdown or Quarto documentation."
 		},
+		"installJupyterlab": {
+			"type": "boolean",
+			"default": false,
+			"description": "Install and setup JupyterLab, a web-based interactive development environment for notebooks."
+		},
 		"pandocVersion": {
 			"type": "string",
 			"proposals": [

--- a/src/r-rig/devcontainer-feature.json
+++ b/src/r-rig/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
 	"name": "R (via rig)",
 	"id": "r-rig",
-	"version": "0.5.0",
+	"version": "0.6.0",
 	"description": "Installs R, some R packages, and needed dependencies. Note: May require source code compilation for R packages.",
 	"documentationURL": "https://github.com/rocker-org/devcontainer-features/tree/main/src/r-rig",
 	"options": {

--- a/src/r-rig/devcontainer-feature.json
+++ b/src/r-rig/devcontainer-feature.json
@@ -40,6 +40,11 @@
 			"default": false,
 			"description": "Install and setup JupyterLab, a web-based interactive development environment for notebooks."
 		},
+		"installRadian": {
+			"type": "boolean",
+			"default": false,
+			"description": "Install radian, an R console with multiline editing and rich syntax highlight."
+		},
 		"pandocVersion": {
 			"type": "string",
 			"proposals": [

--- a/src/r-rig/install.sh
+++ b/src/r-rig/install.sh
@@ -2,9 +2,10 @@
 
 R_VERSION=${VERSION:-"release"}
 VSCODE_R_SUPPORT=${VSCODERSUPPORT:-"minimal"}
+INSTALL_DEVTOOLS=${INSTALLDEVTOOLS:-"false"}
 INSTALL_RMARKDOWN=${INSTALLRMARKDOWN:-"false"}
-PANDOC_VERSION=${PANDOCVERSION:-"auto"}
 INSTALL_JUPYTERLAB=${INSTALLJUPYTERLAB:-"false"}
+PANDOC_VERSION=${PANDOCVERSION:-"auto"}
 
 USERNAME=${USERNAME:-"automatic"}
 
@@ -56,6 +57,29 @@ elif [ "${VSCODE_R_SUPPORT}" = "lsp" ] || [ "${VSCODE_R_SUPPORT}" = "languageser
 elif [ "${VSCODE_R_SUPPORT}" = "full" ]; then
     R_PACKAGES+=(languageserver httpgd)
     APT_PACKAGES+=(libxml2-dev libicu-dev libcairo2-dev libfontconfig1-dev libfreetype6-dev libpng-dev)
+fi
+
+if [ "${INSTALL_DEVTOOLS}" = "true" ]; then
+    APT_PACKAGES+=( \
+        make \
+        libgit2-dev \
+        libcurl4-openssl-dev \
+        libxml2-dev \
+        libssl-dev \
+        libfontconfig1-dev \
+        libharfbuzz-dev \
+        libfribidi-dev \
+        libfreetype6-dev \
+        libpng-dev \
+        libtiff-dev \
+        libjpeg-dev \
+        libicu-dev \
+        zlib1g-dev \
+    )
+    R_PACKAGES+=(devtools)
+    if [ "${PANDOC_VERSION}" = "auto" ] && [ ! -x "$(command -v pandoc)" ]; then
+        PANDOC_VERSION="latest"
+    fi
 fi
 
 if [ "${INSTALL_RMARKDOWN}" = "true" ]; then

--- a/src/r-rig/install.sh
+++ b/src/r-rig/install.sh
@@ -310,7 +310,7 @@ install_r_packages ${R_PACKAGES[*]}
 if [ "${INSTALL_JUPYTERLAB}" = "true" ]; then
     echo "Register IRkernel..."
     # shellcheck disable=SC2016
-    su ${USERNAME} -c 'export PATH="/home/'${USERNAME}'/.local/bin:${PATH}"; R -q -e "IRkernel::installspec()"'
+    su ${USERNAME} -c 'export PATH="/home/'${USERNAME}'/.local/bin:/root/.local/bin:${PATH}"; R -q -e "IRkernel::installspec()"'
 fi
 
 # Clean up

--- a/src/r-rig/install.sh
+++ b/src/r-rig/install.sh
@@ -207,7 +207,7 @@ install_pip_packages() {
     packages="$*"
     if [ -n "${packages}" ]; then
         check_pip
-        su ${USERNAME} -c "python3 -m pip install --user --upgrade --no-cache-dir ${packages}"
+        su ${USERNAME} -c "python3 -m pip install --user --upgrade --no-cache-dir --no-warn-script-location ${packages}"
     fi
 }
 
@@ -280,7 +280,8 @@ install_r_packages ${R_PACKAGES[*]}
 # Set up IRkernel
 if [ "${INSTALL_JUPYTERLAB}" = "true" ]; then
     echo "Register IRkernel..."
-    su ${USERNAME} -c 'R -q -e "IRkernel::installspec()"'
+    # shellcheck disable=SC2016
+    su ${USERNAME} -c 'export PATH="/home/'${USERNAME}'/.local/bin:${PATH}"; R -q -e "IRkernel::installspec()"'
 fi
 
 # Clean up

--- a/src/r-rig/install.sh
+++ b/src/r-rig/install.sh
@@ -273,7 +273,7 @@ fi
 echo "Install R packages..."
 # Install the pak package
 # shellcheck disable=SC2016
-su ${USERNAME} -c 'R -q -e "install.packages(\"pak\", repos = sprintf(\"https://r-lib.github.io/p/pak/stable/%s/%s/%s\", .Platform\$pkgType, R.Version()\$os, R.Version()\$arch))"'
+su ${USERNAME} -c 'R -q -e "install.packages(\"pak\", repos = sprintf(\"https://r-lib.github.io/p/pak/devel/%s/%s/%s\", .Platform\$pkgType, R.Version()\$os, R.Version()\$arch))"'
 # shellcheck disable=SC2048 disable=SC2086
 install_r_packages ${R_PACKAGES[*]}
 

--- a/src/r-rig/install.sh
+++ b/src/r-rig/install.sh
@@ -5,6 +5,7 @@ VSCODE_R_SUPPORT=${VSCODERSUPPORT:-"minimal"}
 INSTALL_DEVTOOLS=${INSTALLDEVTOOLS:-"false"}
 INSTALL_RMARKDOWN=${INSTALLRMARKDOWN:-"false"}
 INSTALL_JUPYTERLAB=${INSTALLJUPYTERLAB:-"false"}
+INSTALL_RADIAN=${INSTALLRADIAN:-"false"}
 PANDOC_VERSION=${PANDOCVERSION:-"auto"}
 
 USERNAME=${USERNAME:-"automatic"}
@@ -88,6 +89,10 @@ if [ "${INSTALL_RMARKDOWN}" = "true" ]; then
     if [ "${PANDOC_VERSION}" = "auto" ] && [ ! -x "$(command -v pandoc)" ]; then
         PANDOC_VERSION="latest"
     fi
+fi
+
+if [ "${INSTALL_RADIAN}" = "true" ]; then
+    PIP_PACKAGES+=(radian)
 fi
 
 if [ "${INSTALL_JUPYTERLAB}" = "true" ]; then

--- a/test/_global/r_quarto.sh
+++ b/test/_global/r_quarto.sh
@@ -5,9 +5,30 @@ set -e
 # Optional: Import test library bundled with the devcontainer CLI
 source dev-container-features-test-lib
 
-# Feature-specific tests
-check "check for R" R -q -e "sessionInfo()"
-check "check for quarto" quarto check all
+cat <<"EOF" >/tmp/knitr.qmd
+---
+title: Test
+engine: knitr
+---
 
+```{r}
+cat("Hello Quarto!")
+```
+EOF
+
+cat <<"EOF" >/tmp/jupyter.qmd
+---
+title: Test
+engine: jupyter
+---
+
+```{r}
+cat("Hello Quarto!")
+```
+EOF
+
+# Feature-specific tests
+check "check rendering (knitr)" quarto render /tmp/knitr.qmd
+check "check rendering (jupyter)" quarto render /tmp/jupyter.qmd
 # Report result
 reportResults

--- a/test/_global/scenarios.json
+++ b/test/_global/scenarios.json
@@ -3,7 +3,8 @@
 		"image": "ubuntu:latest",
 		"features": {
 			"r-rig": {
-				"installRMarkdown": true
+				"installRMarkdown": true,
+				"installJupyterlab": true
 			},
 			"quarto-cli": {}
 		}

--- a/test/r-rig/rpackages-source-install.sh
+++ b/test/r-rig/rpackages-source-install.sh
@@ -7,9 +7,11 @@ source dev-container-features-test-lib
 
 # Feature-specific tests
 check "R" R -q -e "sessionInfo()"
-check "rmarkdown" R -q -e 'rmarkdown::pandoc_version()'
 check "languageserver" R -q -e 'names(installed.packages()[, 3])' | grep languageserver
 check "httpgd" R -q -e 'names(installed.packages()[, 3])' | grep httpgd
+check "devtools" R -q -e 'names(installed.packages()[, 3])' | grep devtools
+check "rmarkdown" R -q -e 'rmarkdown::pandoc_version()'
+check "jupyter" sh -c "jupyter kernelspec list" | grep jupyter/kernels/ir
 
 # Report result
 reportResults

--- a/test/r-rig/rpackages-source-install.sh
+++ b/test/r-rig/rpackages-source-install.sh
@@ -12,7 +12,7 @@ check "httpgd" R -q -e 'names(installed.packages()[, 3])' | grep httpgd
 check "devtools" R -q -e 'names(installed.packages()[, 3])' | grep devtools
 check "rmarkdown" R -q -e 'rmarkdown::pandoc_version()'
 check "jupyter" /root/.local/bin/jupyter kernelspec list | grep jupyter/kernels/ir
-check "radian" radian --version
+check "radian" /root/.local/bin/radian --version
 
 # Report result
 reportResults

--- a/test/r-rig/rpackages-source-install.sh
+++ b/test/r-rig/rpackages-source-install.sh
@@ -11,7 +11,7 @@ check "languageserver" R -q -e 'names(installed.packages()[, 3])' | grep languag
 check "httpgd" R -q -e 'names(installed.packages()[, 3])' | grep httpgd
 check "devtools" R -q -e 'names(installed.packages()[, 3])' | grep devtools
 check "rmarkdown" R -q -e 'rmarkdown::pandoc_version()'
-check "jupyter" jupyter kernelspec list | grep jupyter/kernels/ir
+check "jupyter" /root/.local/bin/jupyter kernelspec list | grep jupyter/kernels/ir
 check "radian" radian --version
 
 # Report result

--- a/test/r-rig/rpackages-source-install.sh
+++ b/test/r-rig/rpackages-source-install.sh
@@ -11,7 +11,8 @@ check "languageserver" R -q -e 'names(installed.packages()[, 3])' | grep languag
 check "httpgd" R -q -e 'names(installed.packages()[, 3])' | grep httpgd
 check "devtools" R -q -e 'names(installed.packages()[, 3])' | grep devtools
 check "rmarkdown" R -q -e 'rmarkdown::pandoc_version()'
-check "jupyter" sh -c "jupyter kernelspec list" | grep jupyter/kernels/ir
+check "jupyter" jupyter kernelspec list | grep jupyter/kernels/ir
+check "radian" radian --version
 
 # Report result
 reportResults

--- a/test/r-rig/scenarios.json
+++ b/test/r-rig/scenarios.json
@@ -4,7 +4,10 @@
 		"features": {
 			"r-rig": {
 				"vscodeRSupport": "full",
-				"installRMarkdown": true
+				"installDevTools": true,
+				"installRMarkdown": true,
+				"installJupyterlab": true,
+				"installRadian": true
 			}
 		}
 	},
@@ -39,7 +42,8 @@
 		"features": {
 			"r-rig": {
 				"version": "none",
-				"installRMarkdown": true
+				"installRMarkdown": true,
+				"installJupyterlab": true
 			}
 		}
 	}


### PR DESCRIPTION
close #18, close #35, close #46

With this update, the packages installed on the following Dockerfile can be installed by this feature.
https://github.com/microsoft/vscode-dev-containers/blob/1d482aca6136a2d24c46e32ad645df54109143ac/containers/r/.devcontainer/Dockerfile

Note: This update is to make this feature also available for use in installing these packages in `rocker/r-ver`, etc.
So I am switching `pak` to the nightly version (0.3.1.9000 or later) that has not yet been released. (See r-lib/pak#251)