### PR TITLE
[quarto-cli][r-rig] Add `installAfter` settings

### DIFF
--- a/src/quarto-cli/devcontainer-feature.json
+++ b/src/quarto-cli/devcontainer-feature.json
@@ -20,6 +20,9 @@
 			"description": "Install TinyTeX by using the `quarto tools install tinytex` command. Works only with version 1.2 or later."
 		}
 	},
+	"installsAfter": [
+		"ghcr.io/devcontainers/features/common-utils"
+	],
 	"customizations": {
 		"vscode": {
 			"extensions": [

--- a/src/quarto-cli/devcontainer-feature.json
+++ b/src/quarto-cli/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
 	"name": "Quarto CLI",
 	"id": "quarto-cli",
-	"version": "0.3.3",
+	"version": "0.3.4",
 	"description": "Installs the Quarto CLI. Auto-detects latest version.",
 	"documentationURL": "https://github.com/rocker-org/devcontainer-features/tree/main/src/quarto-cli",
 	"options": {

--- a/src/quarto-cli/install.sh
+++ b/src/quarto-cli/install.sh
@@ -7,6 +7,9 @@ USERNAME=${USERNAME:-"automatic"}
 
 set -e
 
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
 if [ "$(id -u)" -ne 0 ]; then
     echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
@@ -109,9 +112,6 @@ install_cli() {
 }
 
 export DEBIAN_FRONTEND=noninteractive
-
-# Clean up
-rm -rf /var/lib/apt/lists/*
 
 check_packages curl ca-certificates
 

--- a/src/r-rig/devcontainer-feature.json
+++ b/src/r-rig/devcontainer-feature.json
@@ -62,6 +62,10 @@
 			"description": "Select version of Pandoc. By default, the latest version is installed if needed."
 		}
 	},
+	"installsAfter": [
+		"ghcr.io/devcontainers/features/common-utils",
+		"ghcr.io/devcontainers/features/python"
+	],
 	"customizations": {
 		"vscode": {
 			"extensions": [

--- a/src/r-rig/devcontainer-feature.json
+++ b/src/r-rig/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
 	"name": "R (via rig)",
 	"id": "r-rig",
-	"version": "0.7.0",
+	"version": "0.7.1",
 	"description": "Installs R, some R packages, and needed dependencies. Note: May require source code compilation for R packages.",
 	"documentationURL": "https://github.com/rocker-org/devcontainer-features/tree/main/src/r-rig",
 	"options": {

--- a/src/r-rig/install.sh
+++ b/src/r-rig/install.sh
@@ -17,6 +17,9 @@ R_PACKAGES=()
 
 set -e
 
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
 if [ "$(id -u)" -ne 0 ]; then
     echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
@@ -242,9 +245,6 @@ install_pip_packages() {
 }
 
 export DEBIAN_FRONTEND=noninteractive
-
-# Clean up
-rm -rf /var/lib/apt/lists/*
 
 if [ ! -x "$(command -v git)" ]; then
     APT_PACKAGES+=(git)


### PR DESCRIPTION
close #57

Set these to the `installAfter` properties because they have dependencies on the creation of a non-root user by `common-utils` or on Python 3 installed by `python`.