### PR TITLE
[quarto-cli][r-rig] v1.0.0 Release

### DIFF
--- a/src/quarto-cli/devcontainer-feature.json
+++ b/src/quarto-cli/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
 	"name": "Quarto CLI",
 	"id": "quarto-cli",
-	"version": "0.3.4",
+	"version": "1.0.0",
 	"description": "Installs the Quarto CLI. Auto-detects latest version.",
 	"documentationURL": "https://github.com/rocker-org/devcontainer-features/tree/main/src/quarto-cli",
 	"options": {

--- a/src/r-rig/devcontainer-feature.json
+++ b/src/r-rig/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
 	"name": "R (via rig)",
 	"id": "r-rig",
-	"version": "0.7.3",
+	"version": "1.0.0",
 	"description": "Installs R, some R packages, and needed dependencies. Note: May require source code compilation for R packages.",
 	"documentationURL": "https://github.com/rocker-org/devcontainer-features/tree/main/src/r-rig",
 	"options": {

--- a/test/quarto-cli/scenarios.json
+++ b/test/quarto-cli/scenarios.json
@@ -9,8 +9,8 @@
 		}
 	},
 	"jupyter_quarto": {
-		"image": "mcr.microsoft.com/devcontainers/anaconda:3",
-		"remoteUser": "vscode",
+		"image": "jupyter/base-notebook:latest",
+		"remoteUser": "jovyan",
 		"features": {
 			"quarto-cli": {}
 		}


### PR DESCRIPTION
Close #62

Since [the current published features](https://containers.dev/features) are basically version 1.0, I would like to bump the version numbers to 1.0 in line with other features before these are in wide use.