### PR TITLE
New feature: pandoc

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,6 +6,7 @@ on:
     paths:
       - src/**
       - test/**
+      - "!**.md"
   workflow_dispatch:
 
 concurrency:
@@ -23,6 +24,7 @@ jobs:
         id: filter
         with:
           filters: |
+            pandoc: ./**/pandoc/**
             quarto-cli: ./**/quarto-cli/**
             r-apt: ./**/r-apt/**
             r-rig: ./**/r-rig/**
@@ -75,6 +77,7 @@ jobs:
     strategy:
       matrix:
         features:
+          - pandoc
           - quarto-cli
           - r-apt
           - r-rig
@@ -100,6 +103,7 @@ jobs:
     strategy:
       matrix:
         features:
+          - pandoc
           - quarto-cli
           - r-apt
           - r-rig

--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ and intended to make it easy to add R-related functionality on top of the Debian
 
 ## Contents
 
+### [`pandoc`](src/pandoc/README.md)
+
+Install [Pandoc](https://pandoc.org/).
+
 ### [`quarto-cli`](src/quarto-cli/README.md)
 
 Install [the Quarto CLI](https://quarto.org/).

--- a/src/pandoc/NOTES.md
+++ b/src/pandoc/NOTES.md
@@ -1,0 +1,20 @@
+<!-- markdownlint-disable MD041 -->
+
+## Supported platforms
+
+`linux/amd64` and `linux/arm64` platforms `debian` and `ubuntu`.
+
+## Available versions
+
+This feature automatically fills in the missing part of the version number
+and selects the latest version number among them.
+
+For example, if version `2.17` is specified as follows, version `2.17.1.1` will be installed.
+
+```json
+"features": {
+    "ghcr.io/rocker-org/devcontainer-features/pandoc:latest": {
+        "version": "2.17"
+    }
+}
+```

--- a/src/pandoc/devcontainer-feature.json
+++ b/src/pandoc/devcontainer-feature.json
@@ -1,0 +1,21 @@
+{
+	"name": "Pandoc",
+	"id": "pandoc",
+	"version": "0.1.0",
+	"description": "Installs Pandoc, a universal document converter.",
+	"documentationURL": "https://github.com/rocker-org/devcontainer-features/tree/main/src/pandoc",
+	"options": {
+		"version": {
+			"type": "string",
+			"proposals": [
+				"latest",
+				"2"
+			],
+			"default": "latest",
+			"description": "Select version of Pandoc, if not latest."
+		}
+	},
+	"installsAfter": [
+		"ghcr.io/devcontainers/features/common-utils"
+	]
+}

--- a/src/pandoc/install.sh
+++ b/src/pandoc/install.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+
+PANDOC_VERSION=${VERSION:-"latest"}
+
+set -e
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    exit 1
+fi
+
+# Check the platform
+architecture="$(dpkg --print-architecture)"
+if [ "${architecture}" != "amd64" ] && [ "${architecture}" != "arm64" ]; then
+    echo "(!) Architecture $architecture unsupported"
+    exit 1
+fi
+
+apt_get_update() {
+    if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+        echo "Running apt-get update..."
+        apt-get update -y
+    fi
+}
+
+# Checks if packages are installed and installs them if not
+check_packages() {
+    if ! dpkg -s "$@" >/dev/null 2>&1; then
+        apt_get_update
+        apt-get -y install --no-install-recommends "$@"
+    fi
+}
+
+check_git() {
+    if [ ! -x "$(command -v git)" ]; then
+        check_packages git
+    fi
+}
+
+find_version_from_git_tags() {
+    local variable_name=$1
+    local requested_version=${!variable_name}
+    if [ "${requested_version}" = "none" ]; then return; fi
+    local repository=$2
+    local prefix=${3:-"tags/v"}
+    local separator=${4:-"."}
+    local last_part_optional=${5:-"false"}
+    if [ "$(echo "${requested_version}" | grep -o "." | wc -l)" != "2" ]; then
+        local escaped_separator=${separator//./\\.}
+        local last_part
+        if [ "${last_part_optional}" = "true" ]; then
+            last_part="(${escaped_separator}[0-9]+)*"
+        else
+            last_part="${escaped_separator}[0-9]+"
+        fi
+        local regex="${prefix}\\K[0-9]+${escaped_separator}[0-9]+${last_part}$"
+        local version_list
+        check_git
+        check_packages ca-certificates
+        version_list="$(git ls-remote --tags "${repository}" | grep -oP "${regex}" | tr -d ' ' | tr "${separator}" "." | sort -rV)"
+        if [ "${requested_version}" = "latest" ] || [ "${requested_version}" = "current" ] || [ "${requested_version}" = "lts" ]; then
+            declare -g "${variable_name}"="$(echo "${version_list}" | head -n 1)"
+        else
+            set +e
+            declare -g "${variable_name}"="$(echo "${version_list}" | grep -E -m 1 "^${requested_version//./\\.}([\\.\\s]|$)")"
+            set -e
+        fi
+    fi
+    if [ -z "${!variable_name}" ] || ! echo "${version_list}" | grep "^${!variable_name//./\\.}$" >/dev/null 2>&1; then
+        echo -e "Invalid ${variable_name} value: ${requested_version}\nValid values:\n${version_list}" >&2
+        exit 1
+    fi
+    echo "${variable_name}=${!variable_name}"
+}
+
+install_pandoc() {
+    local version=$1
+    local deb_file="pandoc.deb"
+    local architecture
+    local download_url
+    architecture="$(dpkg --print-architecture)"
+    download_url="https://github.com/jgm/pandoc/releases/download/${version}/pandoc-${version}-1-${architecture}.deb"
+    check_packages curl ca-certificates
+    mkdir -p /tmp/pandoc
+    pushd /tmp/pandoc
+    curl -sLo "${deb_file}" "${download_url}"
+    dpkg -i "${deb_file}"
+    popd
+    rm -rf /tmp/pandoc
+}
+
+export DEBIAN_FRONTEND=noninteractive
+
+# Install Pandoc
+echo "Downloading Pandoc..."
+
+
+find_version_from_git_tags PANDOC_VERSION "https://github.com/jgm/pandoc" "tags/" "." "true"
+echo "Downloading pandoc ${PANDOC_VERSION}..."
+install_pandoc "${PANDOC_VERSION}"
+
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
+echo "Done!"

--- a/src/pandoc/install.sh
+++ b/src/pandoc/install.sh
@@ -95,13 +95,9 @@ install_pandoc() {
 export DEBIAN_FRONTEND=noninteractive
 
 # Install Pandoc
-echo "Downloading Pandoc..."
-
-
 find_version_from_git_tags PANDOC_VERSION "https://github.com/jgm/pandoc" "tags/" "." "true"
 echo "Downloading pandoc ${PANDOC_VERSION}..."
 install_pandoc "${PANDOC_VERSION}"
-
 
 # Clean up
 rm -rf /var/lib/apt/lists/*

--- a/test/_global/r-apt_pandoc.sh
+++ b/test/_global/r-apt_pandoc.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
+apt_get_update() {
+    if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+        echo "Running apt-get update..."
+        apt-get update -y
+    fi
+}
+
+check_packages() {
+    if ! dpkg -s "$@" >/dev/null 2>&1; then
+        apt_get_update
+        apt-get -y install --no-install-recommends "$@"
+    fi
+}
+
+check_packages git ca-certificates
+LATEST_VERSION="$(git ls-remote --tags https://github.com/jgm/pandoc | grep -oP "[0-9]+\\.[0-9]+(\\.[0-9])*" | sort -V | tail -n 1)"
+
+# shellcheck source=/dev/null
+source dev-container-features-test-lib
+
+# Feature-specific tests
+check "R" R -q -e "sessionInfo()"
+check "pandoc" R -q -e 'rmarkdown::pandoc_version()' | grep "$LATEST_VERSION"
+
+# Report result
+reportResults

--- a/test/_global/scenarios.json
+++ b/test/_global/scenarios.json
@@ -18,5 +18,14 @@
 			},
 			"quarto-cli": {}
 		}
+	},
+	"r-apt_pandoc": {
+		"image": "ubuntu:latest",
+		"features": {
+			"r-apt": {
+				"installRMarkdown": true
+			},
+			"pandoc": {}
+		}
 	}
 }

--- a/test/pandoc/scenarios.json
+++ b/test/pandoc/scenarios.json
@@ -1,0 +1,10 @@
+{
+	"version-specific": {
+		"image": "debian:stable-slim",
+		"features": {
+			"pandoc": {
+				"version": "2.17"
+			}
+		}
+	}
+}

--- a/test/pandoc/test.sh
+++ b/test/pandoc/test.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
+apt_get_update() {
+    if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+        echo "Running apt-get update..."
+        apt-get update -y
+    fi
+}
+
+check_packages() {
+    if ! dpkg -s "$@" >/dev/null 2>&1; then
+        apt_get_update
+        apt-get -y install --no-install-recommends "$@"
+    fi
+}
+
+check_packages git ca-certificates
+LATEST_VERSION="$(git ls-remote --tags https://github.com/jgm/pandoc | grep -oP "[0-9]+\\.[0-9]+(\\.[0-9])*" | sort -V | tail -n 1)"
+
+# shellcheck source=/dev/null
+source dev-container-features-test-lib
+
+# Feature-specific tests
+check "Pandoc" pandoc --version | grep "$LATEST_VERSION"
+
+# Report result
+reportResults

--- a/test/pandoc/version-specific.sh
+++ b/test/pandoc/version-specific.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e
+
+# shellcheck source=/dev/null
+source dev-container-features-test-lib
+
+# Feature-specific tests
+check "Pandoc" pandoc --version | grep 2.17.1.1
+
+# Report result
+reportResults


### PR DESCRIPTION
`r-apt` have no option to install the latest Pandoc unlike `r-rig`, so adds a separated feature to install latest Pandoc.
(This feature is a partial cutout of `r-rig`)