### PR TITLE
[r-apt] Remove unused version option

### DIFF
--- a/src/r-apt/README.md
+++ b/src/r-apt/README.md
@@ -17,7 +17,6 @@ Installs the latest R, some R packages, and needed dependencies. Note: May requi
 
 | Options Id | Description | Type | Default Value |
 |-----|-----|-----|-----|
-| version | Currently unused. | string | latest |
 | vscodeRSupport | Install R packages to make vscode-R work. lsp means the `languageserver` package, full means lsp plus the `httpgd` package. | string | minimal |
 | installDevTools | Install the `devtools` R package. | boolean | - |
 | installRMarkdown | Install the `rmarkdown` R package. It is required for R Markdown or Quarto documentation. | boolean | - |

--- a/src/r-apt/devcontainer-feature.json
+++ b/src/r-apt/devcontainer-feature.json
@@ -1,18 +1,10 @@
 {
 	"name": "R (via apt)",
 	"id": "r-apt",
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"description": "Installs the latest R, some R packages, and needed dependencies. Note: May require source code compilation for some R packages.",
 	"documentationURL": "https://github.com/rocker-org/devcontainer-features/tree/main/src/r-apt",
 	"options": {
-		"version": {
-			"type": "string",
-			"proposals": [
-				"latest"
-			],
-			"default": "latest",
-			"description": "Currently unused."
-		},
 		"vscodeRSupport": {
 			"type": "string",
 			"enum": [


### PR DESCRIPTION
If the version option is not used, there seems to be no problem with deleting it. (c.f. `ghcr.io/devcontainers/features/common-utils`)