### PR TITLE
[pandoc] Bump to v1.0.0

### DIFF
--- a/src/pandoc/devcontainer-feature.json
+++ b/src/pandoc/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
 	"name": "Pandoc",
 	"id": "pandoc",
-	"version": "0.1.0",
+	"version": "1.0.0",
 	"description": "Installs Pandoc, a universal document converter.",
 	"documentationURL": "https://github.com/rocker-org/devcontainer-features/tree/main/src/pandoc",
 	"options": {


### PR DESCRIPTION
Since this feature is cut from the `r-rig` feature and contains only code that has been modified many times in `r-rig`, it can be version 1.0.0.