### PR TITLE
[Docs] Remove `remoteUser` from examples

### DIFF
--- a/src/quarto-cli/NOTES.md
+++ b/src/quarto-cli/NOTES.md
@@ -43,7 +43,6 @@ You can also specify a version number, like `"1"`, `"1.2"`, `"1.0.38"`.
         "ghcr.io/rocker-org/devcontainer-features/quarto-cli:latest": {
             "version": "1"
         }
-    },
-    "remoteUser": "vscode"
+    }
 }
 ```

--- a/src/r-rig/NOTES.md
+++ b/src/r-rig/NOTES.md
@@ -37,7 +37,6 @@ You can configure this in `remoteEnv` in `devcontainer.json` as like follows.
     "features": {
         "ghcr.io/rocker-org/devcontainer-features/r-rig:latest": {}
     },
-    "remoteUser": "vscode",
     "remoteEnv": {
         "PKG_SYSREQS": "true"
     }


### PR DESCRIPTION
No longer needed.