### PR TITLE
[r-rig] This feature should not add a `.gitconfig` file to the user's home

### DIFF
--- a/src/r-rig/devcontainer-feature.json
+++ b/src/r-rig/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
 	"name": "R (via rig)",
 	"id": "r-rig",
-	"version": "1.1.1",
+	"version": "1.1.2",
 	"description": "Installs R, some R packages, and needed dependencies. Note: May require source code compilation for R packages.",
 	"documentationURL": "https://github.com/rocker-org/devcontainer-features/tree/main/src/r-rig",
 	"options": {

--- a/src/r-rig/install.sh
+++ b/src/r-rig/install.sh
@@ -317,7 +317,7 @@ echo "Install R packages..."
 # Should not add .gitconfig to the user's home directory
 # https://github.com/r-lib/credentials/issues/25
 if [ ! -f "${_REMOTE_USER_HOME}/.gitconfig" ]; then
-    echo "There is no .gitconfig file in the user's home directory..."
+    echo "There is no ${_REMOTE_USER_HOME}/.gitconfig file..."
     DELETE_GITCONFIG=true
 fi
 
@@ -333,8 +333,8 @@ rm -rf /tmp/r-rig
 
 # Should not add .gitconfig to the user's home directory
 # https://github.com/r-lib/credentials/issues/25
-if [ "${DELETE_GITCONFIG}" = "true" ]; then
-    echo "Removing .gitconfig file in the user's home directory..."
+if [ "${DELETE_GITCONFIG}" = "true" ] && [ -f "${_REMOTE_USER_HOME}/.gitconfig" ] ; then
+    echo "Remove ${_REMOTE_USER_HOME}/.gitconfig file..."
     rm -f "${_REMOTE_USER_HOME}/.gitconfig"
 fi
 

--- a/src/r-rig/install.sh
+++ b/src/r-rig/install.sh
@@ -313,6 +313,14 @@ else
 fi
 
 echo "Install R packages..."
+
+# Should not add .gitconfig to the user's home directory
+# https://github.com/r-lib/credentials/issues/25
+if [ ! -f "${_REMOTE_USER_HOME}/.gitconfig" ]; then
+    echo "There is no .gitconfig file in the user's home directory..."
+    DELETE_GITCONFIG=true
+fi
+
 # Install the pak package
 mkdir /tmp/r-rig
 pushd /tmp/r-rig
@@ -322,6 +330,13 @@ su ${USERNAME} -c 'R -q -e "install.packages(\"pak\", repos = sprintf(\"https://
 install_r_packages ${R_PACKAGES[*]}
 popd
 rm -rf /tmp/r-rig
+
+# Should not add .gitconfig to the user's home directory
+# https://github.com/r-lib/credentials/issues/25
+if [ "${DELETE_GITCONFIG}" = "true" ]; then
+    echo "Removing .gitconfig file in the user's home directory..."
+    rm -f "${_REMOTE_USER_HOME}/.gitconfig"
+fi
 
 # Set up IRkernel
 if [ "${INSTALL_JUPYTERLAB}" = "true" ]; then


### PR DESCRIPTION
Addresses rocker-org/devcontainer-images#39

It appears that the `~/.gitconfig` file is generated when the `credentials` package is source installed. (r-lib/credentials#25)
Until this can be circumvented, the generated `.gitconfig` file should be removed.