### PR TITLE
[miniforge] Bump to v1.0.0

### DIFF
--- a/src/miniforge/devcontainer-feature.json
+++ b/src/miniforge/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
 	"name": "Conda, Mamba (Miniforge)",
 	"id": "miniforge",
-	"version": "0.1.2",
+	"version": "1.0.0",
 	"description": "Installs Conda and Mamba package manager and Python3. conda-forge set as the default (and only) channel.",
 	"documentationURL": "https://github.com/rocker-org/devcontainer-features/tree/main/src/miniforge",
 	"options": {

--- a/src/miniforge/install.sh
+++ b/src/miniforge/install.sh
@@ -46,7 +46,7 @@ if [ "${USERNAME}" = "auto" ] || [ "${USERNAME}" = "automatic" ]; then
     if [ "${USERNAME}" = "" ]; then
         USERNAME=root
     fi
-elif [ "${USERNAME}" = "none" ] || ! id -u ${USERNAME} >/dev/null 2>&1; then
+elif [ "${USERNAME}" = "none" ] || ! id -u "${USERNAME}" >/dev/null 2>&1; then
     USERNAME=root
 fi
 


### PR DESCRIPTION
It has been downloaded 2,000 times and seems to be stable enough, so bump to version 1.0.0.