### PR TITLE
[r-rig] Minor fix of test (check radian's path)

### DIFF
--- a/test/r-rig/python-packages-global.sh
+++ b/test/r-rig/python-packages-global.sh
@@ -7,7 +7,7 @@ source dev-container-features-test-lib
 
 # Feature-specific tests
 check "R" R -q -e "sessionInfo()"
-check "radian" radian --version
+check "radian" /usr/local/bin/radian --version
 
 # Report result
 reportResults


### PR DESCRIPTION
In #63, I added a test to check the path of radian when radian is installed on an image with a non-root user, but the user in the test has switched from root to non-root user, so I need to update the test to check the path.