### PR TITLE
[r-rig] Add a new option to choose pak version to be installed

### DIFF
--- a/src/r-rig/devcontainer-feature.json
+++ b/src/r-rig/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
 	"name": "R (via rig)",
 	"id": "r-rig",
-	"version": "1.1.2",
+	"version": "1.2.0",
 	"description": "Installs R, some R packages, and needed dependencies. Note: May require source code compilation for R packages.",
 	"documentationURL": "https://github.com/rocker-org/devcontainer-features/tree/main/src/r-rig",
 	"options": {

--- a/src/r-rig/devcontainer-feature.json
+++ b/src/r-rig/devcontainer-feature.json
@@ -15,6 +15,16 @@
 			"default": "release",
 			"description": "Select version of R, if not the latest release version."
 		},
+		"pakVersion": {
+			"type": "string",
+			"enum": [
+				"auto",
+				"devel",
+				"stable"
+			],
+			"default": "auto",
+			"description": "Version of pak to install. By default, the devel version is installed if needed."
+		},
 		"vscodeRSupport": {
 			"type": "string",
 			"enum": [

--- a/src/r-rig/install.sh
+++ b/src/r-rig/install.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 R_VERSION=${VERSION:-"release"}
+PAK_VERSION=${PAKVERSION:-"auto"}
 VSCODE_R_SUPPORT=${VSCODERSUPPORT:-"minimal"}
 INSTALL_DEVTOOLS=${INSTALLDEVTOOLS:-"false"}
 INSTALL_RENV=${INSTALLRENV:-"false"}
@@ -238,6 +239,23 @@ install_pandoc() {
     rm -rf /tmp/pandoc
 }
 
+install_pak() {
+    local version=$1
+
+    if [ "${version}" = "auto" ]; then
+        if su "${USERNAME}" -c "R -s -e 'packageVersion(\"pak\")'" >/dev/null 2>&1; then
+            echo "pak is already installed. Skip pak installation..."
+            return
+        else
+            version="devel"
+        fi
+    fi
+
+    echo "Installing pak ${version}..."
+    # shellcheck disable=SC2016
+    su "${USERNAME}" -c 'R -q -e "install.packages(\"pak\", repos = sprintf(\"https://r-lib.github.io/p/pak/'"${version}"'/%s/%s/%s\", .Platform\$pkgType, R.Version()\$os, R.Version()\$arch))"'
+}
+
 install_r_packages() {
     local packages="$*"
     if [ -n "${packages}" ]; then
@@ -324,6 +342,8 @@ fi
 # Install the pak package
 mkdir /tmp/r-rig
 pushd /tmp/r-rig
+
+install_pak "${PAK_VERSION}"
 # shellcheck disable=SC2016
 su ${USERNAME} -c 'R -q -e "install.packages(\"pak\", repos = sprintf(\"https://r-lib.github.io/p/pak/devel/%s/%s/%s\", .Platform\$pkgType, R.Version()\$os, R.Version()\$arch))"'
 # shellcheck disable=SC2048 disable=SC2086

--- a/src/r-rig/install.sh
+++ b/src/r-rig/install.sh
@@ -46,7 +46,7 @@ if [ "${USERNAME}" = "auto" ] || [ "${USERNAME}" = "automatic" ]; then
     if [ "${USERNAME}" = "" ]; then
         USERNAME=root
     fi
-elif [ "${USERNAME}" = "none" ] || ! id -u ${USERNAME} >/dev/null 2>&1; then
+elif [ "${USERNAME}" = "none" ] || ! id -u "${USERNAME}" >/dev/null 2>&1; then
     USERNAME=root
 fi
 
@@ -259,7 +259,7 @@ install_pak() {
 install_r_packages() {
     local packages="$*"
     if [ -n "${packages}" ]; then
-        su ${USERNAME} -c "R -q -e \"pak::pak(unlist(strsplit('${packages}', ' ')))\""
+        su "${USERNAME}" -c "R -q -e \"pak::pak(unlist(strsplit('${packages}', ' ')))\""
     fi
 }
 
@@ -345,7 +345,7 @@ pushd /tmp/r-rig
 
 install_pak "${PAK_VERSION}"
 # shellcheck disable=SC2016
-su ${USERNAME} -c 'R -q -e "install.packages(\"pak\", repos = sprintf(\"https://r-lib.github.io/p/pak/devel/%s/%s/%s\", .Platform\$pkgType, R.Version()\$os, R.Version()\$arch))"'
+su "${USERNAME}" -c 'R -q -e "install.packages(\"pak\", repos = sprintf(\"https://r-lib.github.io/p/pak/devel/%s/%s/%s\", .Platform\$pkgType, R.Version()\$os, R.Version()\$arch))"'
 # shellcheck disable=SC2048 disable=SC2086
 install_r_packages ${R_PACKAGES[*]}
 popd
@@ -362,7 +362,7 @@ fi
 if [ "${INSTALL_JUPYTERLAB}" = "true" ]; then
     echo "Register IRkernel..."
     # shellcheck disable=SC2016
-    su ${USERNAME} -c 'export PATH="/home/'${USERNAME}'/.local/bin:/root/.local/bin:${PATH}"; R -q -e "IRkernel::installspec()"'
+    su "${USERNAME}" -c 'export PATH="/home/'"${USERNAME}"'/.local/bin:/root/.local/bin:${PATH}"; R -q -e "IRkernel::installspec()"'
 fi
 
 # Clean up

--- a/test/r-rig/install-on-devcontainer-r-ver.sh
+++ b/test/r-rig/install-on-devcontainer-r-ver.sh
@@ -6,8 +6,8 @@ set -e
 source dev-container-features-test-lib
 
 # Feature-specific tests
-check "R" R --version | grep 4.0.5
-check "pandoc" R -q -e 'rmarkdown::pandoc_version()'
+check "R" R --version
+check "jupyter" jupyter kernelspec list
 
 # Report result
 reportResults

--- a/test/r-rig/scenarios.json
+++ b/test/r-rig/scenarios.json
@@ -14,18 +14,20 @@
 		}
 	},
 	"latest-pandoc": {
-		"image": "ubuntu:latest",
+		"image": "rocker/r-ver:4",
 		"features": {
 			"r-rig": {
+				"version": "none",
 				"installRMarkdown": true,
 				"pandocVersion": "latest"
 			}
 		}
 	},
 	"os-pandoc": {
-		"image": "ubuntu:latest",
+		"image": "rocker/r-ver:4",
 		"features": {
 			"r-rig": {
+				"version": "none",
 				"installRMarkdown": true,
 				"pandocVersion": "os-provided"
 			}
@@ -55,12 +57,11 @@
 			}
 		}
 	},
-	"install-on-rocker-r-ver": {
-		"image": "rocker/r-ver:4.0.5",
+	"install-on-devcontainer-r-ver": {
+		"image": "ghcr.io/rocker-org/devcontainer/r-ver:4",
 		"features": {
 			"r-rig": {
 				"version": "none",
-				"installRMarkdown": true,
 				"installJupyterlab": true
 			}
 		}


### PR DESCRIPTION
Copied the `pakVersion` option from #120.

If we are installing R packages with this Feature on an R-installed image, `pak` may already be installed.
The default is to skip `pak` installation if `pak` is already installed.