### PR TITLE
[renv-cache] Create cache dir in the image to fix permission error

### DIFF
--- a/src/renv-cache/devcontainer-feature.json
+++ b/src/renv-cache/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
 	"name": "renv cache",
 	"id": "renv-cache",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"description": "Install the renv R package and set renv cache to a Docker volume. Cache is shared by all containers.",
 	"documentationURL": "https://github.com/rocker-org/devcontainer-features/tree/main/src/renv-cache",
 	"options": {},

--- a/src/renv-cache/install.sh
+++ b/src/renv-cache/install.sh
@@ -1,23 +1,43 @@
 #!/bin/sh
 
+RENV_PATHS_CACHE=${RENV_PATHS_CACHE:-"/renv/cache"}
+
 USERNAME=${USERNAME:-${_REMOTE_USER}}
 
 set -e
 
-if [ ! -x "$(command -v R)" ]; then
-    echo "(!) Cannot run R. Please install R before installing this Feature."
-    echo "    Skip installation..."
-    exit 0
-fi
+create_cache_dir() {
+    if [ -d "$1" ]; then
+        echo "Cache directory $1 already exists. Skip creation..."
+    else
+        echo "Create cache directory $1..."
+        mkdir -p "$1"
+    fi
+
+    if [ -z "$2" ]; then
+        echo "No username provided. Skip chown..."
+    else
+        echo "Change owner of $1 to $2..."
+        chown -R "$2:$2" "$1"
+    fi
+}
+
+check_r() {
+    if [ ! -x "$(command -v R)" ]; then
+        echo "(!) Cannot run R. Please install R before installing this Feature."
+        echo "    Skip installation..."
+        exit 0
+    fi
+}
 
 install_renv() {
-    if su "${USERNAME}" -c "R -s -e 'packageVersion(\"renv\")'" >/dev/null 2>&1; then
+    if su "$1" -c "R -s -e 'packageVersion(\"renv\")'" >/dev/null 2>&1; then
         echo "renv R package is already installed. Skip renv installation..."
     else
         echo "Install renv R package..."
         mkdir /tmp/renv-cache
         cd /tmp/renv-cache
-        su "${USERNAME}" -c "R -s -e 'install.packages(\"renv\")'"
+        su "$1" -c "R -s -e 'install.packages(\"renv\")'"
         cd ..
         rm -rf /tmp/renv-cache
         rm -rf /tmp/Rtmp*
@@ -26,6 +46,8 @@ install_renv() {
 
 export DEBIAN_FRONTEND=noninteractive
 
-install_renv
+create_cache_dir "${RENV_PATHS_CACHE}" "${USERNAME}"
+check_r
+install_renv "${USERNAME}"
 
 echo "Done!"


### PR DESCRIPTION
When I used this Feature in my VS Code Dev Containers, the cache directory was owned by root and the cache directory could not be used unless the ownership was manually changed.

Local test with an R package project

```json
{
	"name": "R (rocker/r-ver base)",
	"image": "ghcr.io/rocker-org/devcontainer/r-ver:4",
	"features": {
		"./renv-cache": {}
	},
	"postCreateCommand": "R -q -e 'renv::install()'"
}
```

![image](https://user-images.githubusercontent.com/50911393/211182996-540a6093-62d2-4de4-a389-7aabbc6f6128.png)
