### PR TITLE
[miniforge] no fail on existing installation

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -15,7 +15,7 @@
 		}
 	},
 	"features": {
-		"ghcr.io/devcontainers/features/docker-from-docker:1": {
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {
 			"version": "latest"
 		}
 	},

--- a/src/miniforge/devcontainer-feature.json
+++ b/src/miniforge/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
 	"name": "Conda, Mamba (Miniforge)",
 	"id": "miniforge",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "Installs Conda and Mamba package manager and Python3. conda-forge set as the default (and only) channel.",
 	"documentationURL": "https://github.com/rocker-org/devcontainer-features/tree/main/src/miniforge",
 	"options": {

--- a/src/miniforge/install.sh
+++ b/src/miniforge/install.sh
@@ -12,13 +12,13 @@ set -e
 rm -rf /var/lib/apt/lists/*
 
 if conda --version &>/dev/null; then
-    echo "(!) conda is already installed."
-    exit 1
+    echo "(!) conda is already installed - exiting."
+    exit 0
 fi
 
 if mamba --version &>/dev/null; then
-    echo "(!) mamba is already installed."
-    exit 1
+    echo "(!) mamba is already installed - exiting."
+    exit 0
 fi
 
 if [ "$(id -u)" -ne 0 ]; then

--- a/test/miniforge/mambaforge-existing-conda.sh
+++ b/test/miniforge/mambaforge-existing-conda.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e
+
+# shellcheck source=/dev/null
+source dev-container-features-test-lib
+
+# Check that conda is installed
+check "conda" conda --version 
+
+# Report result
+reportResults

--- a/test/miniforge/scenarios.json
+++ b/test/miniforge/scenarios.json
@@ -22,5 +22,12 @@
 				"variant": "Mambaforge-pypy3"
 			}
 		}
+	},
+	"mambaforge-existing-conda": {
+		"image": "jupyter/base-notebook",
+		"features":{
+			"miniforge": {}
+		},
+		"containerUser": "root"
 	}
 }


### PR DESCRIPTION
Fixes #166 

Note that this does not handle the case where the existing version is not the version requested. I started to address it, but it is made more complicated by the fact that mambaforge versions don't seem to keep up with official conda releases, so I didn't venture further down that path (i.e. if someone comes with an image with a fresh conda install, we would almost certainly be down-grading it here, which might not be desired).

I also updated the devcontainer spec of this repo because it was using an outdated `docker-from-docker` feature, which in turn made the tests in the tests break when running in the devcontainer.  