### PR TITLE
feat: add rstudio

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,6 +32,7 @@ jobs:
             r-packages: ./**/r-packages/**
             r-rig: ./**/r-rig/**
             renv-cache: ./**/renv-cache/**
+            rstudio: ./**/rstudio/**
 
   test-detects:
     needs:
@@ -89,6 +90,7 @@ jobs:
           - r-packages
           - r-rig
           - renv-cache
+          - rstudio
         baseImage:
           - debian:stable-slim
           - ubuntu:focal
@@ -119,6 +121,7 @@ jobs:
           - r-packages
           - r-rig
           - renv-cache
+          - rstudio
     steps:
       - uses: actions/checkout@v3
 

--- a/src/rstudio/README.md
+++ b/src/rstudio/README.md
@@ -1,0 +1,5 @@
+
+# RStudio
+
+Installs RStudio
+

--- a/src/rstudio/devcontainer-feature.json
+++ b/src/rstudio/devcontainer-feature.json
@@ -1,0 +1,27 @@
+{
+	"name": "RStudio",
+	"id": "rstudio",
+	"version": "1.0.0",
+	"description": "Installs RStudio",
+	"options": {
+		"password": {
+			"type": "string",
+			"description": "Password to use for default user.",
+			"default": ""
+		},
+		"rstudioVersion": {
+			"type": "string",
+			"description": "RStudio version to install.",
+			"default": "2023.09.0-daily+301"
+		}
+	},
+	"installsAfter": [
+		"ghcr.io/devcontainers/features/common-utils",
+		"ghcr.io/devcontainers/nvidia-cuda"
+	],
+	"dependsOn": {
+		"ghcr.io/rocker-org/devcontainer-features/apt-packages": {
+			"packages": "r-base,ca-certificates,lsb-release,file,git,libapparmor1,libclang-dev,libcurl4-openssl-dev,libedit2,libobjc4,libssl-dev,libpq5,psmisc,procps,python-setuptools,pwgen,sudo,wget"
+		}
+	}
+}

--- a/src/rstudio/install.sh
+++ b/src/rstudio/install.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -e
+
+export DEBIAN_FRONTEND=noninteractive
+export DEFAULT_USER=${_REMOTE_USER}
+export RSTUDIO_VERSION=$RSTUDIOVERSION
+export PASSWORD=${PASSWORD:-$DEFAULT_USER}
+
+bash ./rocker_scripts/install_rstudio.sh
+
+# create the directories and configurations
+mkdir /tmp/rstudio-server-data
+mkdir /tmp/db-conf
+
+cat <<EOF> /tmp/db-conf/db.conf
+provider=sqlite
+directory=/tmp/db-conf
+EOF
+
+chown -R ${DEFAULT_USER}:${DEFAULT_USER} /tmp/rstudio-server-data
+chown -R ${DEFAULT_USER}:${DEFAULT_USER} /tmp/db-conf

--- a/src/rstudio/rocker_scripts/default_user.sh
+++ b/src/rstudio/rocker_scripts/default_user.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+## This is adapted from the script used in https://github.com/rocker-org/rocker-versioned2
+
+set -e
+
+DEFAULT_USER=${1:-${DEFAULT_USER:-"rstudio"}}
+
+if id -u "${DEFAULT_USER}" >/dev/null 2>&1; then
+    echo "User ${DEFAULT_USER} already exists"
+else
+    ## Need to configure non-root user for RStudio
+    useradd -s /bin/bash -m "$DEFAULT_USER"
+    echo "${DEFAULT_USER}:${PASSWORD}" | chpasswd
+    usermod -a -G staff "${DEFAULT_USER}"
+
+    ## Rocker's default RStudio settings, for better reproducibility
+    mkdir -p "/home/${DEFAULT_USER}/.config/rstudio/"
+    cat <<EOF >"/home/${DEFAULT_USER}/.config/rstudio/rstudio-prefs.json"
+{
+    "save_workspace": "never",
+    "always_save_history": false,
+    "reuse_sessions_for_project_links": true,
+    "posix_terminal_shell": "bash"
+}
+EOF
+    chown -R "${DEFAULT_USER}:${DEFAULT_USER}" "/home/${DEFAULT_USER}"
+fi
+
+# If shiny server installed, make the user part of the shiny group
+if [ -x "$(command -v shiny-server)" ]; then
+    adduser "${DEFAULT_USER}" shiny
+fi
+
+## configure git not to request password each time
+if [ -x "$(command -v git)" ]; then
+    git config --system credential.helper 'cache --timeout=3600'
+    git config --system push.default simple
+fi

--- a/src/rstudio/rocker_scripts/install_rstudio.sh
+++ b/src/rstudio/rocker_scripts/install_rstudio.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+## This is adapted from the script used in https://github.com/rocker-org/rocker-versioned2
+
+## Download and install RStudio server & dependencies uses.
+##
+## In order of preference, first argument of the script, the RSTUDIO_VERSION variable.
+## ex. stable, preview, daily, 1.3.959, 2021.09.1+372, 2021.09.1-372, 2022.06.0-daily+11
+
+set -e
+
+RSTUDIO_VERSION=${1:-${RSTUDIO_VERSION:-"stable"}}
+DEFAULT_USER=${DEFAULT_USER:-"rstudio"}
+
+# shellcheck source=/dev/null
+source /etc/os-release
+
+ARCH=$(dpkg --print-architecture)
+
+## Download RStudio Server for Ubuntu 18+
+DOWNLOAD_FILE=rstudio-server.deb
+
+if [ "$RSTUDIO_VERSION" = "latest" ]; then
+    RSTUDIO_VERSION="stable"
+fi
+
+# if [ "$UBUNTU_CODENAME" = "focal" ]; then
+#     UBUNTU_CODENAME="bionic"
+# fi
+
+if [ "$RSTUDIO_VERSION" = "stable" ] || [ "$RSTUDIO_VERSION" = "preview" ] || [ "$RSTUDIO_VERSION" = "daily" ]; then
+    # if [ "$UBUNTU_CODENAME" = "bionic" ]; then
+    #     UBUNTU_CODENAME="focal"
+    # fi
+    wget "https://rstudio.org/download/latest/${RSTUDIO_VERSION}/server/${UBUNTU_CODENAME}/rstudio-server-latest-${ARCH}.deb" -O "$DOWNLOAD_FILE"
+else
+    wget "https://download2.rstudio.org/server/${UBUNTU_CODENAME}/${ARCH}/rstudio-server-${RSTUDIO_VERSION/"+"/"-"}-${ARCH}.deb" -O "$DOWNLOAD_FILE" ||
+        wget "https://s3.amazonaws.com/rstudio-ide-build/server/${UBUNTU_CODENAME}/${ARCH}/rstudio-server-${RSTUDIO_VERSION/"+"/"-"}-${ARCH}.deb" -O "$DOWNLOAD_FILE"
+fi
+
+dpkg -i "$DOWNLOAD_FILE"
+rm "$DOWNLOAD_FILE"
+
+ln -fs /usr/lib/rstudio-server/bin/rstudio-server /usr/local/bin
+ln -fs /usr/lib/rstudio-server/bin/rserver /usr/local/bin
+
+# https://github.com/rocker-org/rocker-versioned2/issues/137
+rm -f /var/lib/rstudio-server/secure-cookie-key
+
+## RStudio wants an /etc/R, will populate from $R_HOME/etc
+mkdir -p /etc/R
+
+## Make RStudio compatible with case when R is built from source
+## (and thus is at /usr/local/bin/R), because RStudio doesn't obey
+## path if a user apt-get installs a package
+R_BIN=$(which R)
+echo "rsession-which-r=${R_BIN}" >/etc/rstudio/rserver.conf
+## use more robust file locking to avoid errors when using shared volumes:
+echo "lock-type=advisory" >/etc/rstudio/file-locks
+
+## Prepare optional configuration file to disable authentication
+## To de-activate authentication, `disable_auth_rserver.conf` script
+## will just need to be overwrite /etc/rstudio/rserver.conf.
+## This is triggered by an env var in the user config
+cp /etc/rstudio/rserver.conf /etc/rstudio/disable_auth_rserver.conf
+echo "auth-none=1" >>/etc/rstudio/disable_auth_rserver.conf
+
+# If CUDA enabled, make sure RStudio knows (config_cuda_R.sh handles this anyway)
+if [ -n "$CUDA_HOME" ]; then
+    sed -i '/^rsession-ld-library-path/d' /etc/rstudio/rserver.conf
+    echo "rsession-ld-library-path=$LD_LIBRARY_PATH" >>/etc/rstudio/rserver.conf
+fi
+
+# Log to stderr
+cat <<EOF >/etc/rstudio/logging.conf
+[*]
+log-level=debug
+logger-type=syslog
+EOF
+
+# set up default user
+bash ./rocker_scripts/default_user.sh "${DEFAULT_USER}"
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
+# Check the RStudio Server
+echo -e "Check the RStudio Server version...\n"
+
+rstudio-server version
+
+echo -e "\nInstall RStudio Server, done!"

--- a/test/rstudio/test.sh
+++ b/test/rstudio/test.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Optional: Import test library bundled with the devcontainer CLI
+source dev-container-features-test-lib
+
+# Feature-specific tests
+check "rserver is installed" rstudio-server version
+
+# Report result
+reportResults


### PR DESCRIPTION
Here is an attempt to add an RStudio feature. 

I was having some issues getting the no-auth to work, I could use some hints. Basically the browser entered into some sort of redirect loop; with auth it works fine. 

Also note that this is using a feature preview of the devcontainers feature spec, namely the `dependsOn` property so schema checkers complain. 

An example `devcontainer.json`:

```json
{
	"image": "ubuntu",
	"features": {
		"./rstudio": {}
	},
	"remoteUser": "rstudio",
	"portsAttributes": {
		"56559": {
			"label": "RStudio port",
			"onAutoForward": "openBrowser"
		}
	},
	"forwardPorts": [56559],
	"postStartCommand": "rserver --auth-none=0 --www-frame-origin=same --www-port=56559 --www-verify-user-agent=0 --secure-cookie-key-file=/tmp/rstudio-cookie-file --server-user=$(whoami) --database-config-file=/tmp/db-conf/db.conf --server-data-dir=/tmp/rstudio-server-data",
}
```

Some things left to do:

- [ ] enable no-auth (cannot figure it out, could use help!) 
- [ ] verify that it works with various versions of RStudio
- [ ] open the browser automatically? 
- [ ] streamline install scripts further?

closes #71 