### PR TITLE
[rstudio-server] support for updating already existing prefs.json

### DIFF
--- a/src/rstudio-server/NOTES.md
+++ b/src/rstudio-server/NOTES.md
@@ -31,6 +31,27 @@ Since `rserver` uses the 8787 port by default, `"forwardPorts": [8787]` is also 
 }
 ```
 
+## RStudio's initial working directory
+
+This Feature sets `onCreateCommand`, and the `onCreateCommand` sets `initial_working_directory`
+to file `rstudio-prefs.json` immediately after container creation.
+
+If `rstudio-prefs.json` already exists when the container is created,
+the `jq` command must be installed to update `rstudio-prefs.json`.
+
+For example, we can install `jq` with the
+[`ghcr.io/rocker-org/devcontainer-features/apt-packages`](https://github.com/rocker-org/devcontainer-features/tree/main/src/apt-packages)
+Feature as follows:
+
+```json
+"features": {
+    "ghcr.io/rocker-org/devcontainer-features/apt-packages:1": {
+        "packages": "jq"
+    },
+    "ghcr.io/rocker-org/devcontainer-features/rstudio-server": {}
+}
+```
+
 ## Available versions
 
 `"stable"` and `"daily"` refer to the latest stable and daily builds

--- a/src/rstudio-server/devcontainer-feature.json
+++ b/src/rstudio-server/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
 	"name": "RStudio Server",
 	"id": "rstudio-server",
-	"version": "0.1.0",
+	"version": "0.2.0",
 	"description": "Installs the RStudio Server, enables to run the RStudio IDE on the browser.",
 	"documentationURL": "https://github.com/rocker-org/devcontainer-features/tree/main/src/rstudio-server",
 	"options": {

--- a/src/rstudio-server/oncreate.sh
+++ b/src/rstudio-server/oncreate.sh
@@ -18,7 +18,8 @@ set_rstudio_prefs() {
     "initial_working_directory": "${cur_dir}"
 }
 EOF
-        echo "Done!"
+    elif jq '.' "${prefs_path}" >/dev/null 2>&1; then
+        jq ".initial_working_directory = \"${cur_dir}\"" "${prefs_path}" >"${prefs_path}.tmp" && mv "${prefs_path}.tmp" "${prefs_path}"
     fi
 }
 

--- a/test/rstudio-server/scenarios.json
+++ b/test/rstudio-server/scenarios.json
@@ -28,5 +28,16 @@
 				"version": "2023.09.0-daily+310"
 			}
 		}
+	},
+	"update-prefs": {
+		"build": {
+			"dockerfile": "Dockerfile"
+		},
+		"features": {
+			"ghcr.io/rocker-org/devcontainer-features/apt-packages:1": {
+				"packages": "jq"
+			},
+			"rstudio-server":{}
+		}
 	}
 }

--- a/test/rstudio-server/update-prefs.sh
+++ b/test/rstudio-server/update-prefs.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Optional: Import test library bundled with the devcontainer CLI
+source dev-container-features-test-lib
+
+# Feature-specific tests
+export prefs_json_path=~/.config/rstudio/rstudio-prefs.json
+check "version" bash -c 'rstudio-server version'
+check "rstudio prefs 1" bash -c "jq -r '.initial_working_directory' ${prefs_json_path} | grep $(pwd)"
+check "rstudio prefs 2" bash -c "jq -r '.foo' ${prefs_json_path} | grep bar"
+
+# Report result
+reportResults

--- a/test/rstudio-server/update-prefs/Dockerfile
+++ b/test/rstudio-server/update-prefs/Dockerfile
@@ -7,6 +7,7 @@ RUN useradd -s /bin/bash -m rstudio \
 
 USER rstudio
 RUN <<EOF
+mkdir -p ~/.config/rstudio
 cat <<EOF2 >~/.config/rstudio/rstudio-prefs.json
 {
   "initial_working_directory": "/home/rstudio",

--- a/test/rstudio-server/update-prefs/Dockerfile
+++ b/test/rstudio-server/update-prefs/Dockerfile
@@ -1,0 +1,16 @@
+# syntax=docker/dockerfile:1.4
+
+FROM rocker/r-ver:latest
+
+RUN useradd -s /bin/bash -m rstudio \
+    && usermod -a -G staff rstudio
+
+USER rstudio
+RUN <<EOF
+cat <<EOF2 >~/.config/rstudio/rstudio-prefs.json
+{
+  "initial_working_directory": "/home/rstudio",
+  "foo": "bar"
+}
+EOF2
+EOF


### PR DESCRIPTION
Add the ability to update `initial_working_directory` of `rstudio-prefs.json` using the `jq` command if `rstudio-prefs.json` already exists.