### PR TITLE
[rstudio-server] change the `allowReinstall` option's default value to `false`

### DIFF
--- a/src/rstudio-server/devcontainer-feature.json
+++ b/src/rstudio-server/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
 	"name": "RStudio Server",
 	"id": "rstudio-server",
-	"version": "0.2.0",
+	"version": "0.3.0",
 	"description": "Installs the RStudio Server, enables to run the RStudio IDE on the browser.",
 	"documentationURL": "https://github.com/rocker-org/devcontainer-features/tree/main/src/rstudio-server",
 	"options": {
@@ -16,7 +16,7 @@
 		},
 		"allowReinstall": {
 			"type": "boolean",
-			"default": true,
+			"default": false,
 			"description": "Reinstall in case RStudio Server is already installed."
 		},
 		"singleUser": {

--- a/src/rstudio-server/install.sh
+++ b/src/rstudio-server/install.sh
@@ -166,7 +166,7 @@ if [ "${ALLOW_REINSTALL}" = "true" ] || [ ! -x "$(command -v rstudio-server)" ];
 
     install_rstudio "${RS_VERSION}"
 else
-    echo "RStudio Server is already installed. Skip installation..."
+    echo "(!) RStudio Server is already installed. Skip installation..."
 fi
 
 if [ "${SINGLE_USER}" = "true" ]; then

--- a/test/rstudio-server/scenarios.json
+++ b/test/rstudio-server/scenarios.json
@@ -17,7 +17,8 @@
 		"image": "rocker/rstudio",
 		"features": {
 			"rstudio-server": {
-				"version": "daily"
+				"version": "daily",
+				"allowReinstall": true
 			}
 		}
 	},
@@ -25,8 +26,7 @@
 		"image": "rocker/rstudio",
 		"features": {
 			"rstudio-server": {
-				"version": "daily",
-				"allowReinstall": false
+				"version": "daily"
 			}
 		}
 	},


### PR DESCRIPTION
Considering that this Feature is used to change the configuration of an image that already has RStudio Server installed, I think the default should be `false`.