### PR TITLE
chore: Update devcontainer.json and README

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,5 +1,5 @@
 {
-	"image": "mcr.microsoft.com/vscode/devcontainers/javascript-node:0-18",
+	"image": "mcr.microsoft.com/devcontainers/javascript-node:1-18-bullseye",
 	"customizations": {
 		"vscode": {
 			"extensions": [
@@ -10,15 +10,20 @@
 				"redhat.vscode-yaml"
 			],
 			"settings": {
-				"terminal.integrated.defaultProfile.linux": "zsh"
+				"terminal.integrated.defaultProfile.linux": "zsh",
+				"json.schemas": [
+					{
+						"fileMatch": [
+							"*/devcontainer-feature.json"
+						],
+						"url": "https://raw.githubusercontent.com/devcontainers/spec/main/schemas/devContainerFeature.schema.json"
+					}
+				]
 			}
 		}
 	},
 	"features": {
-		"ghcr.io/devcontainers/features/docker-in-docker:2": {
-			"version": "latest"
-		}
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {}
 	},
-	"remoteUser": "node",
-	"postCreateCommand": "npm install -g @devcontainers/cli"
+	"updateContentCommand": "npm install -g @devcontainers/cli"
 }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Dev Container Features (for R)
+# Dev Container Features by Rocker Project
 
 This repository contains a _collection_ of Dev Container Features.
 
@@ -7,13 +7,16 @@ please check [the specification](https://containers.dev/implementors/features/) 
 [the devcontainers' official Development Container Features repository](https://github.com/devcontainers/features).
 
 This repository is based on the [the `devcontainers/features` repository](https://github.com/devcontainers/features),
-and intended to make it easy to add R-related functionality on top of the Debian base containers.
+and intended to make it easy to add Rocker Project related functionality.
 
 ## Contents
 
 ### [`apt-packages`](src/apt-packages/README.md)
 
 Installs packages of the user's choice via apt.
+
+A simple Feature that implements the functionality proposed in
+[devcontainers/features#67](https://github.com/devcontainers/features/issues/67).
 
 ### [`miniforge`](src/miniforge/README.md)
 


### PR DESCRIPTION
Update the outdated container definition as in https://github.com/devcontainers/feature-starter and make minor modifications to the README.