### PR TITLE
[quarto-cli] chromium deps test on ubuntu

### DIFF
--- a/src/quarto-cli/NOTES.md
+++ b/src/quarto-cli/NOTES.md
@@ -65,7 +65,7 @@ On Ubuntu, we need to install missing dependencies by either. For example:
 }
 ```
 
-The package list came from the Puppeteer for WSL. <https://pptr.dev/troubleshooting#running-puppeteer-on-wsl-windows-subsystem-for-linux>
+The package list came from the Puppeteer document. <https://pptr.dev/troubleshooting#running-puppeteer-on-wsl-windows-subsystem-for-linux>
 
 See also: <https://pptr.dev/troubleshooting#running-puppeteer-in-docker>
 

--- a/src/quarto-cli/NOTES.md
+++ b/src/quarto-cli/NOTES.md
@@ -29,8 +29,9 @@ Chromium may be required to render documents containing [diagrams code blocks](h
 such as `{mermaid}` and `{dot}` into non-HTML formats.
 
 To do this in a Docker container, besides specifying the `installChromium` option of this Feature,
-you also need to install Chromium itself.
-For Debian, this can be done with `devcontainer.json` as follows
+we also need to install necessary shared library dependencies of Chromium.
+
+On Debian, this can be done with installing Chromium via `devcontainer.json` as follows
 using the `ghcr.io/rocker-org/devcontainer-features/apt-packages` Feature.
 
 ```json
@@ -47,7 +48,7 @@ using the `ghcr.io/rocker-org/devcontainer-features/apt-packages` Feature.
 }
 ```
 
-Unfortunately, this does not work for Ubuntu because it is not possible to install chromium via apt.
+Unfortunately, this does not work for Ubuntu because it is not possible to install Chromium via apt.
 
 On Ubuntu, we need to install missing dependencies by either. For example:
 
@@ -65,7 +66,8 @@ On Ubuntu, we need to install missing dependencies by either. For example:
 }
 ```
 
-The package list came from the Puppeteer document. <https://pptr.dev/troubleshooting#running-puppeteer-on-wsl-windows-subsystem-for-linux>
+The dependent package list came from [the Puppeteer document](https://pptr.dev/troubleshooting#running-puppeteer-on-wsl-windows-subsystem-for-linux)
+and might get outdated.
 
 See also: <https://pptr.dev/troubleshooting#running-puppeteer-in-docker>
 

--- a/src/quarto-cli/NOTES.md
+++ b/src/quarto-cli/NOTES.md
@@ -49,7 +49,25 @@ using the `ghcr.io/rocker-org/devcontainer-features/apt-packages` Feature.
 
 Unfortunately, this does not work for Ubuntu because it is not possible to install chromium via apt.
 
-See also the Puppeteer documentation. <https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md#running-puppeteer-in-docker>
+On Ubuntu, we need to install missing dependencies by either. For example:
+
+```json
+{
+    "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+    "features": {
+        "ghcr.io/rocker-org/devcontainer-features/quarto-cli:1": {
+            "installChromium": true
+        },
+        "ghcr.io/rocker-org/devcontainer-features/apt-packages:1": {
+            "packages": "libgtk-3-dev,libnotify-dev,libgconf-2-4,libnss3,libxss1,libasound2"
+        }
+    }
+}
+```
+
+The package list came from the Puppeteer for WSL. <https://pptr.dev/troubleshooting#running-puppeteer-on-wsl-windows-subsystem-for-linux>
+
+See also: <https://pptr.dev/troubleshooting#running-puppeteer-in-docker>
 
 ## Available versions
 

--- a/src/quarto-cli/install.sh
+++ b/src/quarto-cli/install.sh
@@ -139,7 +139,7 @@ fi
 if [ "${INSTALL_CHROMIUM}" = "true" ]; then
     echo "Installing chromium..."
     echo "(!) Quarto CLI installs headless Chromium via Puppeteer. The bundled Chromium that Puppeteer installs may not work on Docker containers."
-    echo "    Please check the Puppeteer document: https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md#running-puppeteer-in-docker"
+    echo "    Please check the Puppeteer document: <https://pptr.dev/troubleshooting#running-puppeteer-in-docker>"
     su "${USERNAME}" -c 'quarto tools install chromium'
 fi
 

--- a/test/quarto-cli/chromium-on-ubuntu.sh
+++ b/test/quarto-cli/chromium-on-ubuntu.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Optional: Import test library bundled with the devcontainer CLI
+source dev-container-features-test-lib
+
+cat <<"EOF" >/tmp/test.qmd
+---
+title: Test
+format:
+  gfm:
+    mermaid-format: png
+---
+
+```{mermaid}
+flowchart LR
+  A[Hard edge] --> B(Round edge)
+  B --> C{Decision}
+  C --> D[Result one]
+  C --> E[Result two]
+```
+EOF
+
+# Feature-specific tests
+check "check rendering" quarto render /tmp/test.qmd
+
+# Report result
+reportResults

--- a/test/quarto-cli/scenarios.json
+++ b/test/quarto-cli/scenarios.json
@@ -33,5 +33,16 @@
 				"packages": "chromium"
 			}
 		}
+	},
+	"chromium-on-ubuntu": {
+		"image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+		"features": {
+			"quarto-cli": {
+				"installChromium": true
+			},
+			"ghcr.io/rocker-org/devcontainer-features/apt-packages:1": {
+				"packages": "libgtk-3-dev,libnotify-dev,libgconf-2-4,libnss3,libxss1"
+			}
+		}
 	}
 }

--- a/test/quarto-cli/scenarios.json
+++ b/test/quarto-cli/scenarios.json
@@ -41,7 +41,7 @@
 				"installChromium": true
 			},
 			"ghcr.io/rocker-org/devcontainer-features/apt-packages:1": {
-				"packages": "libgtk-3-dev,libnotify-dev,libgconf-2-4,libnss3,libxss1"
+				"packages": "libgtk-3-dev,libnotify-dev,libgconf-2-4,libnss3,libxss1,libasound2"
 			}
 		}
 	}


### PR DESCRIPTION
The package list came from <https://pptr.dev/next/troubleshooting#running-puppeteer-on-wsl-windows-subsystem-for-linux>