### PR TITLE
[r-packages] allow whitespace in `packages`

### DIFF
--- a/src/r-packages/devcontainer-feature.json
+++ b/src/r-packages/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
 	"name": "R packages (via pak)",
 	"id": "r-packages",
-	"version": "1.1.3",
+	"version": "1.0.4",
 	"description": "Installs R packages via the pak R package's function. R must be already installed.",
 	"documentationURL": "https://github.com/rocker-org/devcontainer-features/tree/main/src/r-packages",
 	"options": {

--- a/src/r-packages/devcontainer-feature.json
+++ b/src/r-packages/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
 	"name": "R packages (via pak)",
 	"id": "r-packages",
-	"version": "1.0.3",
+	"version": "1.1.3",
 	"description": "Installs R packages via the pak R package's function. R must be already installed.",
 	"documentationURL": "https://github.com/rocker-org/devcontainer-features/tree/main/src/r-packages",
 	"options": {

--- a/src/r-packages/install.sh
+++ b/src/r-packages/install.sh
@@ -92,7 +92,7 @@ install_r_packages() {
             fi
         fi
 
-        su "${USERNAME}" -c "R -q -e \"pak::repo_add(${ADDITIONAL_REPOSITORIES}); pak::pak(unlist(strsplit('${packages}', ','))); pak::cache_clean()\""
+        su "${USERNAME}" -c "R -q -e \"pak::repo_add(${ADDITIONAL_REPOSITORIES}); pak::pak(trimws(unlist(strsplit('${packages}', ',')))); pak::cache_clean()\""
 
         if [ "${is_apt}" = "true" ]; then
             # Clean up

--- a/test/apt-packages/install-curl-nano-wget-ws.sh
+++ b/test/apt-packages/install-curl-nano-wget-ws.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Optional: Import test library bundled with the devcontainer CLI
+source dev-container-features-test-lib
+
+# Feature-specific tests
+check "curl" curl --version
+check "nano" nano --version
+check "wget" wget --version
+
+# Report result
+reportResults

--- a/test/apt-packages/scenarios.json
+++ b/test/apt-packages/scenarios.json
@@ -7,6 +7,14 @@
 			}
 		}
 	},
+	"install-curl-nano-wget-ws": {
+		"image": "debian:stable-slim",
+		"features": {
+			"apt-packages": {
+				"packages": "curl, nano, wget"
+			}
+		}
+	},
 	"only-upgrade": {
 		"image": "debian:stable-slim",
 		"features": {

--- a/test/r-packages/install-cli-rlang-ws.sh
+++ b/test/r-packages/install-cli-rlang-ws.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Optional: Import test library bundled with the devcontainer CLI
+source dev-container-features-test-lib
+
+# Feature-specific tests
+check "R cli package" R -q -e 'names(installed.packages()[, 3])' | grep cli
+check "R rlang package" R -q -e 'names(installed.packages()[, 3])' | grep rlang
+
+# Report result
+reportResults

--- a/test/r-packages/scenarios.json
+++ b/test/r-packages/scenarios.json
@@ -7,6 +7,14 @@
 			}
 		}
 	},
+	"install-cli-rlang-ws": {
+		"image": "rocker/r-ver:4",
+		"features": {
+			"r-packages": {
+				"packages": "cli, rlang"
+			}
+		}
+	},
 	"install-from-github": {
 		"image": "rocker/r-ver:4",
 		"features": {


### PR DESCRIPTION
This is a small change to allow for whitespace in the `packages` specification, so that using

```jsonc
"packages": "cli, rlang"
```

does not lead to an error.