### PR TITLE
Update ownership of `$RENV_PATHS_CACHE` to correct uid on `postStartCommand`

### DIFF
--- a/src/renv-cache/devcontainer-feature.json
+++ b/src/renv-cache/devcontainer-feature.json
@@ -15,6 +15,9 @@
 			"type": "volume"
 		}
 	],
+	"postStartCommand": {
+		"renv-cache-setup": "/usr/local/share/rocker-devcontainer-features/renv-cache/scripts/poststart.sh"
+	},
 	"installsAfter": [
 		"ghcr.io/devcontainers/features/common-utils",
 		"ghcr.io/rocker-org/devcontainer-features/apt-packages",

--- a/src/renv-cache/devcontainer-feature.json
+++ b/src/renv-cache/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
 	"name": "renv cache",
 	"id": "renv-cache",
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"description": "Install the renv R package and set renv cache to a Docker volume. Cache is shared by all containers.",
 	"documentationURL": "https://github.com/rocker-org/devcontainer-features/tree/main/src/renv-cache",
 	"options": {},

--- a/src/renv-cache/install.sh
+++ b/src/renv-cache/install.sh
@@ -4,6 +4,8 @@ RENV_PATHS_CACHE=${RENV_PATHS_CACHE:-"/renv/cache"}
 
 USERNAME=${USERNAME:-${_REMOTE_USER}}
 
+LIFECYCLE_SCRIPTS_DIR="/usr/local/share/rocker-devcontainer-features/renv-cache/scripts"
+
 set -e
 
 create_cache_dir() {
@@ -49,5 +51,11 @@ export DEBIAN_FRONTEND=noninteractive
 create_cache_dir "${RENV_PATHS_CACHE}" "${USERNAME}"
 check_r
 install_renv "${USERNAME}"
+
+# Set Lifecycle scripts
+if [ -f poststart.sh ]; then
+    mkdir -p "${LIFECYCLE_SCRIPTS_DIR}"
+    cp poststart.sh "${LIFECYCLE_SCRIPTS_DIR}/poststart.sh"
+fi
 
 echo "Done!"

--- a/src/renv-cache/install.sh
+++ b/src/renv-cache/install.sh
@@ -49,13 +49,15 @@ install_renv() {
 export DEBIAN_FRONTEND=noninteractive
 
 create_cache_dir "${RENV_PATHS_CACHE}" "${USERNAME}"
-check_r
-install_renv "${USERNAME}"
 
 # Set Lifecycle scripts
+## check_r exits installation if R isn't present, so the script needs to be copied first
 if [ -f poststart.sh ]; then
     mkdir -p "${LIFECYCLE_SCRIPTS_DIR}"
     cp poststart.sh "${LIFECYCLE_SCRIPTS_DIR}/poststart.sh"
 fi
+
+check_r
+install_renv "${USERNAME}"
 
 echo "Done!"

--- a/src/renv-cache/poststart.sh
+++ b/src/renv-cache/poststart.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+RENV_PATHS_CACHE=${RENV_PATHS_CACHE:-"/renv/cache"}
+
+set -e
+
+fix_permissions() {
+    local dir
+    dir="${1}"
+
+    if [ ! -w "${dir}" ]; then
+        echo "Fixing permissions of '${dir}'..."
+        sudo chown -R "$(id -u):$(id -g)" "${dir}"
+        echo "Done!"
+    else
+        echo "Permissions of '${dir}' are OK!"
+    fi
+}
+
+fix_permissions "${RENV_PATHS_CACHE}"

--- a/test/renv-cache/gh-version-renv.sh
+++ b/test/renv-cache/gh-version-renv.sh
@@ -6,6 +6,7 @@ set -e
 source dev-container-features-test-lib
 
 # Feature-specific tests
+check "cache dir permission" bash -c "test -w /renv/cache/"
 check "renv" R -q -e 'packageVersion("renv")'
 check "renv::install" R -q -e 'renv::install("jsonlite")'
 check "cache dir" find /renv/cache/*

--- a/test/renv-cache/r-apt.sh
+++ b/test/renv-cache/r-apt.sh
@@ -6,6 +6,7 @@ set -e
 source dev-container-features-test-lib
 
 # Feature-specific tests
+check "cache dir permission" bash -c "test -w /renv/cache/"
 check "renv" R -q -e 'packageVersion("renv")'
 check "renv::install" R -q -e 'renv::install("jsonlite")'
 check "cache dir" find /renv/cache/*

--- a/test/renv-cache/r-rig.sh
+++ b/test/renv-cache/r-rig.sh
@@ -6,6 +6,7 @@ set -e
 source dev-container-features-test-lib
 
 # Feature-specific tests
+check "cache dir permission" bash -c "test -w /renv/cache/"
 check "renv" R -q -e 'packageVersion("renv")'
 check "renv::install" R -q -e 'renv::install("jsonlite")'
 check "cache dir" find /renv/cache/*

--- a/test/renv-cache/rocker-r-ver.sh
+++ b/test/renv-cache/rocker-r-ver.sh
@@ -6,6 +6,7 @@ set -e
 source dev-container-features-test-lib
 
 # Feature-specific tests
+check "cache dir permission" bash -c "test -w /renv/cache/"
 check "renv" R -q -e 'packageVersion("renv")'
 check "renv::install" R -q -e 'renv::install("jsonlite")'
 check "cache dir" find /renv/cache/*

--- a/test/renv-cache/test.sh
+++ b/test/renv-cache/test.sh
@@ -6,6 +6,7 @@ set -e
 source dev-container-features-test-lib
 
 # Feature-specific tests
+check "cache dir permission" bash -c "test -w /renv/cache/"
 
 # Report result
 reportResults


### PR DESCRIPTION
Closes #209 

Updates the ownership of the `$RENV_PATHS_CACHE` directory such that when `updateRemoteUserUID` is set, the ownership of the cache is the same as the workspace. The test cases have also been updated to check the permissions of the directory.