### PR TITLE
[r-apt][r-packages][r-rig]: install stable version of pak by default (instead of devel version)

### DIFF
--- a/src/r-apt/devcontainer-feature.json
+++ b/src/r-apt/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
 	"name": "R (via apt)",
 	"id": "r-apt",
-	"version": "0.4.1",
+	"version": "0.4.2",
 	"description": "Installs the latest R, some R packages, and needed dependencies. Note: May require source code compilation for some R packages.",
 	"documentationURL": "https://github.com/rocker-org/devcontainer-features/tree/main/src/r-apt",
 	"options": {

--- a/src/r-apt/install.sh
+++ b/src/r-apt/install.sh
@@ -189,7 +189,7 @@ chmod g+ws "${R_LIBRARY_PATH}"
 install_pip_packages ${PIP_PACKAGES[*]}
 
 # Install pak
-R -q -e "install.packages(\"pak\", repos = sprintf(\"https://r-lib.github.io/p/pak/devel/%s/%s/%s\", .Platform\$pkgType, R.Version()\$os, R.Version()\$arch))"
+R -q -e "install.packages(\"pak\", repos = sprintf(\"https://r-lib.github.io/p/pak/stable/%s/%s/%s\", .Platform\$pkgType, R.Version()\$os, R.Version()\$arch))"
 
 if [ "${ID}" = "debian" ] && [ "${install_languageserver}" = "true" ]; then
     check_packages \

--- a/src/r-packages/devcontainer-feature.json
+++ b/src/r-packages/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
 	"name": "R packages (via pak)",
 	"id": "r-packages",
-	"version": "1.0.4",
+	"version": "1.0.5",
 	"description": "Installs R packages via the pak R package's function. R must be already installed.",
 	"documentationURL": "https://github.com/rocker-org/devcontainer-features/tree/main/src/r-packages",
 	"options": {
@@ -22,7 +22,7 @@
 				"stable"
 			],
 			"default": "auto",
-			"description": "Version of pak to install. By default, the devel version is installed if needed."
+			"description": "Version of pak to install. By default, the stable version is installed if needed."
 		},
 		"additionalRepositories": {
 			"type": "string",

--- a/src/r-packages/install.sh
+++ b/src/r-packages/install.sh
@@ -64,7 +64,7 @@ install_pak() {
             echo "pak is already installed. Skip pak installation..."
             return
         else
-            version="devel"
+            version="stable"
         fi
     fi
 

--- a/src/r-rig/devcontainer-feature.json
+++ b/src/r-rig/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
 	"name": "R (via rig)",
 	"id": "r-rig",
-	"version": "1.2.3",
+	"version": "1.2.4",
 	"description": "Installs R, some R packages, and needed dependencies. Note: May require source code compilation for R packages.",
 	"documentationURL": "https://github.com/rocker-org/devcontainer-features/tree/main/src/r-rig",
 	"options": {
@@ -23,7 +23,7 @@
 				"stable"
 			],
 			"default": "auto",
-			"description": "Version of pak to install. By default, the devel version is installed if needed."
+			"description": "Version of pak to install. By default, the stable version is installed if needed."
 		},
 		"vscodeRSupport": {
 			"type": "string",

--- a/src/r-rig/install.sh
+++ b/src/r-rig/install.sh
@@ -247,7 +247,7 @@ install_pak() {
             echo "pak is already installed. Skip pak installation..."
             return
         else
-            version="devel"
+            version="stable"
         fi
     fi
 


### PR DESCRIPTION
`pak` has been released frequently over the past few years, and I believe the stable version is now sufficient for our needs.