### PR TITLE
test: remove outdated tests and fix pandoc's version regex

### DIFF
--- a/test/_global/r-apt_pandoc.sh
+++ b/test/_global/r-apt_pandoc.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-LATEST_VERSION="$(git ls-remote --tags https://github.com/jgm/pandoc | grep -oP "[0-9]+\\.[0-9]+(\\.[0-9])*" | sort -V | tail -n 1)"
+LATEST_VERSION="$(git ls-remote --tags https://github.com/jgm/pandoc | grep -oP "[0-9]+\\.[0-9]+(\\.[0-9]+)*" | sort -V | tail -n 1)"
 
 # shellcheck source=/dev/null
 source dev-container-features-test-lib

--- a/test/_global/r-apt_pandoc.sh
+++ b/test/_global/r-apt_pandoc.sh
@@ -2,24 +2,6 @@
 
 set -e
 
-# Clean up
-rm -rf /var/lib/apt/lists/*
-
-apt_get_update() {
-    if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
-        echo "Running apt-get update..."
-        apt-get update -y
-    fi
-}
-
-check_packages() {
-    if ! dpkg -s "$@" >/dev/null 2>&1; then
-        apt_get_update
-        apt-get -y install --no-install-recommends "$@"
-    fi
-}
-
-check_packages git ca-certificates
 LATEST_VERSION="$(git ls-remote --tags https://github.com/jgm/pandoc | grep -oP "[0-9]+\\.[0-9]+(\\.[0-9])*" | sort -V | tail -n 1)"
 
 # shellcheck source=/dev/null

--- a/test/miniforge/mambaforge-pypy3.sh
+++ b/test/miniforge/mambaforge-pypy3.sh
@@ -2,24 +2,6 @@
 
 set -e
 
-# Clean up
-rm -rf /var/lib/apt/lists/*
-
-apt_get_update() {
-    if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
-        echo "Running apt-get update..."
-        apt-get update -y
-    fi
-}
-
-check_packages() {
-    if ! dpkg -s "$@" >/dev/null 2>&1; then
-        apt_get_update
-        apt-get -y install --no-install-recommends "$@"
-    fi
-}
-
-check_packages git ca-certificates
 LATEST_VERSION="$(git ls-remote --tags https://github.com/conda-forge/miniforge | grep -oP "[0-9]+\\.[0-9]+.[0-9]+" | sort -V | tail -n 1)"
 
 # shellcheck source=/dev/null

--- a/test/miniforge/miniforge-pypy3.sh
+++ b/test/miniforge/miniforge-pypy3.sh
@@ -2,24 +2,6 @@
 
 set -e
 
-# Clean up
-rm -rf /var/lib/apt/lists/*
-
-apt_get_update() {
-    if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
-        echo "Running apt-get update..."
-        apt-get update -y
-    fi
-}
-
-check_packages() {
-    if ! dpkg -s "$@" >/dev/null 2>&1; then
-        apt_get_update
-        apt-get -y install --no-install-recommends "$@"
-    fi
-}
-
-check_packages git ca-certificates
 LATEST_VERSION="$(git ls-remote --tags https://github.com/conda-forge/miniforge | grep -oP "[0-9]+\\.[0-9]+.[0-9]+" | sort -V | tail -n 1)"
 
 # shellcheck source=/dev/null

--- a/test/miniforge/miniforge3.sh
+++ b/test/miniforge/miniforge3.sh
@@ -2,24 +2,6 @@
 
 set -e
 
-# Clean up
-rm -rf /var/lib/apt/lists/*
-
-apt_get_update() {
-    if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
-        echo "Running apt-get update..."
-        apt-get update -y
-    fi
-}
-
-check_packages() {
-    if ! dpkg -s "$@" >/dev/null 2>&1; then
-        apt_get_update
-        apt-get -y install --no-install-recommends "$@"
-    fi
-}
-
-check_packages git ca-certificates
 LATEST_VERSION="$(git ls-remote --tags https://github.com/conda-forge/miniforge | grep -oP "[0-9]+\\.[0-9]+.[0-9]+" | sort -V | tail -n 1)"
 
 # shellcheck source=/dev/null

--- a/test/miniforge/test.sh
+++ b/test/miniforge/test.sh
@@ -2,24 +2,6 @@
 
 set -e
 
-# Clean up
-rm -rf /var/lib/apt/lists/*
-
-apt_get_update() {
-    if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
-        echo "Running apt-get update..."
-        apt-get update -y
-    fi
-}
-
-check_packages() {
-    if ! dpkg -s "$@" >/dev/null 2>&1; then
-        apt_get_update
-        apt-get -y install --no-install-recommends "$@"
-    fi
-}
-
-check_packages git ca-certificates
 LATEST_VERSION="$(git ls-remote --tags https://github.com/conda-forge/miniforge | grep -oP "[0-9]+\\.[0-9]+.[0-9]+" | sort -V | tail -n 1)"
 
 # shellcheck source=/dev/null

--- a/test/pandoc/test.sh
+++ b/test/pandoc/test.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-LATEST_VERSION="$(git ls-remote --tags https://github.com/jgm/pandoc | grep -oP "[0-9]+\\.[0-9]+(\\.[0-9])*" | sort -V | tail -n 1)"
+LATEST_VERSION="$(git ls-remote --tags https://github.com/jgm/pandoc | grep -oP "[0-9]+\\.[0-9]+(\\.[0-9]+)*" | sort -V | tail -n 1)"
 
 # shellcheck source=/dev/null
 source dev-container-features-test-lib

--- a/test/pandoc/test.sh
+++ b/test/pandoc/test.sh
@@ -2,24 +2,6 @@
 
 set -e
 
-# Clean up
-rm -rf /var/lib/apt/lists/*
-
-apt_get_update() {
-    if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
-        echo "Running apt-get update..."
-        apt-get update -y
-    fi
-}
-
-check_packages() {
-    if ! dpkg -s "$@" >/dev/null 2>&1; then
-        apt_get_update
-        apt-get -y install --no-install-recommends "$@"
-    fi
-}
-
-check_packages git ca-certificates
 LATEST_VERSION="$(git ls-remote --tags https://github.com/jgm/pandoc | grep -oP "[0-9]+\\.[0-9]+(\\.[0-9])*" | sort -V | tail -n 1)"
 
 # shellcheck source=/dev/null

--- a/test/r-rig/latest-pandoc.sh
+++ b/test/r-rig/latest-pandoc.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-LATEST_VERSION="$(git ls-remote --tags https://github.com/jgm/pandoc | grep -oP "[0-9]+\\.[0-9]+(\\.[0-9])*" | sort -V | tail -n 1)"
+LATEST_VERSION="$(git ls-remote --tags https://github.com/jgm/pandoc | grep -oP "[0-9]+\\.[0-9]+(\\.[0-9]+)*" | sort -V | tail -n 1)"
 
 # shellcheck source=/dev/null
 source dev-container-features-test-lib

--- a/test/r-rig/latest-pandoc.sh
+++ b/test/r-rig/latest-pandoc.sh
@@ -2,24 +2,6 @@
 
 set -e
 
-# Clean up
-rm -rf /var/lib/apt/lists/*
-
-apt_get_update() {
-    if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
-        echo "Running apt-get update..."
-        apt-get update -y
-    fi
-}
-
-check_packages() {
-    if ! dpkg -s "$@" >/dev/null 2>&1; then
-        apt_get_update
-        apt-get -y install --no-install-recommends "$@"
-    fi
-}
-
-check_packages git ca-certificates
 LATEST_VERSION="$(git ls-remote --tags https://github.com/jgm/pandoc | grep -oP "[0-9]+\\.[0-9]+(\\.[0-9])*" | sort -V | tail -n 1)"
 
 # shellcheck source=/dev/null


### PR DESCRIPTION
Currently the devcontainer CLI may not use the root user during testing, so these codes need to be removed.