### PR TITLE
docs(r-apt): Added case-sensitivity of apt packages warning

### DIFF
--- a/src/apt-packages/NOTES.md
+++ b/src/apt-packages/NOTES.md
@@ -14,18 +14,6 @@ The following example installs `curl` and `nano`.
 }
 ```
 
-### Specifiying R packages
-
-When installing R packages via `r-cran-<package>`, note that R package name references must be lowercase. For example, the following example installs the {kableExtra} R package.
-
-```json
-"features": {
-    "ghcr.io/rocker-org/devcontainer-features/apt-packages:1": {
-        "packages": "r-cran-kableextra"
-    }
-}
-```
-
 ## Installation order
 
 Specify the installation order of Features

--- a/src/apt-packages/NOTES.md
+++ b/src/apt-packages/NOTES.md
@@ -14,6 +14,18 @@ The following example installs `curl` and `nano`.
 }
 ```
 
+### Specifiying R packages
+
+When installing R packages via `r-cran-<package>`, note that R package name references must be lowercase. For example, the following example installs the {kableExtra} R package.
+
+```json
+"features": {
+    "ghcr.io/rocker-org/devcontainer-features/apt-packages:1": {
+        "packages": "r-cran-kableextra"
+    }
+}
+```
+
 ## Installation order
 
 Specify the installation order of Features

--- a/src/r-apt/NOTES.md
+++ b/src/r-apt/NOTES.md
@@ -29,7 +29,7 @@ apt-get -y install --no-install-recommends r-cran-dplyr
 Thanks to [r2u](https://eddelbuettel.github.io/r2u/), on Ubuntu,
 all packages on CRAN and BioConductor can be installed via apt.
 
-If you want to install R packages via apt during the container build phase,
+If you want to install R packages via apt during the container build phase (as opposed to installing R packages using the [`r-packages` Feature](https://github.com/rocker-org/devcontainer-features/tree/main/src/r-packages)),
 you can use [the `ghcr.io/rocker-org/devcontainer-features/apt-packages` Feature](https://github.com/rocker-org/devcontainer-features/blob/main/src/apt-packages)
 to do so.
 
@@ -47,6 +47,20 @@ to do so.
 
 `ghcr.io/rocker-org/devcontainer-features/apt-packages` is not guaranteed to install after this Feature,
 so be sure to set up [the `overrideFeatureInstallOrder` property](https://containers.dev/implementors/features/#overrideFeatureInstallOrder).
+
+When installing R packages via `r-cran-<package>` using the `apt-packages` Feature, R package name references must be lowercase. For example, the following snippet installs the {kableExtra} R package.
+
+```json
+"features": {
+    "ghcr.io/rocker-org/devcontainer-features/r-apt:latest": {},
+    "ghcr.io/rocker-org/devcontainer-features/apt-packages:1": {
+        "packages": "r-cran-kableextra"
+    }
+},
+"overrideFeatureInstallOrder": [
+    "ghcr.io/rocker-org/devcontainer-features/r-apt"
+]
+```
 
 ### Source installation via R
 


### PR DESCRIPTION
Considering R users who may used to installing R packages via `install.packages(...)` (where package names may be a mix of upper- and lower-case letters) from an R session, I believe it may be useful to document that installing R packages via `apt-packages` requires that the package name be lowercase within `r-cran-<package>`.